### PR TITLE
Add grblHAL controller alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For a more complete introduction, see the [Introduction](https://github.com/cncj
     - [Smoothieware](https://github.com/Smoothieware/Smoothieware) ([Download](https://github.com/Smoothieware/Smoothieware/tree/edge/FirmwareBin))
     - [TinyG](https://github.com/synthetos/TinyG) (_Recommend: firmware version 0.97 build 449.xx_) ([Download](http://synthetos.github.io/))
     - [g2core](https://github.com/synthetos/g2)
+    - [grblHAL](https://github.com/grblHAL)
 * [Desktop App for Linux, Mac OS X, and Windows](https://github.com/cncjs/cncjs/wiki/Desktop-App)
 * 6-axis digital readout (DRO)
 * Tool path 3D visualization
@@ -147,7 +148,7 @@ pi@rpi3$ cncjs -h
     -w, --watch-directory <path>        Watch a directory for changes
     --access-token-lifetime <lifetime>  Access token lifetime in seconds or a time span string (default: 30d)
     --allow-remote-access               Allow remote access to the server (default: false)
-    --controller <type>                 Specify CNC controller: Grbl|Marlin|Smoothie|TinyG|g2core (default: '')
+    --controller <type>                 Specify CNC controller: Grbl|grblHAL|Marlin|Smoothie|TinyG|g2core (default: '')
     -h, --help                          output usage information
 
   Examples:
@@ -160,6 +161,7 @@ pi@rpi3$ cncjs -h
     $ cncjs --access-token-lifetime 60d  # e.g. 3600, 30m, 12h, 30d
     $ cncjs --allow-remote-access
     $ cncjs --controller Grbl
+    $ cncjs --controller grblHAL
 ```
 
 Instead of passing command line options for `--watch-directory`, `--access-token-lifetime`, `--allow-remote-access`, and `--controller`, you can create a `~/.cncrc` file that contains the following configuration in JSON format:

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "smoothieware",
     "tinyg",
     "g2core",
+    "grblhal",
     "react",
     "socket.io"
   ],

--- a/src/app/constants/index.js
+++ b/src/app/constants/index.js
@@ -65,6 +65,7 @@ export const METRIC_STEPS = [
 
 // Controller
 export const GRBL = 'Grbl';
+export const GRBLHAL = 'grblHAL';
 export const MARLIN = 'Marlin';
 export const SMOOTHIE = 'Smoothie';
 export const TINYG = 'TinyG';

--- a/src/app/containers/Workspace/PrimaryWidgets.jsx
+++ b/src/app/containers/Workspace/PrimaryWidgets.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Sortable from 'react-sortablejs';
 import uuid from 'uuid';
-import { GRBL, MARLIN, SMOOTHIE, TINYG } from 'app/constants';
+import { GRBL, GRBLHAL, MARLIN, SMOOTHIE, TINYG } from 'app/constants';
 import { Button } from 'app/components/Buttons';
 import Modal from 'app/components/Modal';
 import controller from 'app/lib/controller';

--- a/src/app/containers/Workspace/PrimaryWidgets.jsx
+++ b/src/app/containers/Workspace/PrimaryWidgets.jsx
@@ -190,7 +190,10 @@ class PrimaryWidgets extends Component {
         .filter(widgetId => {
           // e.g. "webcam" or "webcam:d8e6352f-80a9-475f-a4f5-3e9197a48a23"
           const name = widgetId.split(':')[0];
-          if (name === 'grbl' && !includes(controller.loadedControllers, GRBL)) {
+          if (name === 'grbl' && !includes(controller.loadedControllers, GRBL) && !includes(controller.loadedControllers, GRBLHAL)) {
+            return false;
+          }
+          if (name === 'grblhal' && !includes(controller.loadedControllers, GRBLHAL)) {
             return false;
           }
           if (name === 'marlin' && !includes(controller.loadedControllers, MARLIN)) {

--- a/src/app/containers/Workspace/SecondaryWidgets.jsx
+++ b/src/app/containers/Workspace/SecondaryWidgets.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Sortable from 'react-sortablejs';
 import uuid from 'uuid';
-import { GRBL, MARLIN, SMOOTHIE, TINYG } from 'app/constants';
+import { GRBL, GRBLHAL, MARLIN, SMOOTHIE, TINYG } from 'app/constants';
 import { Button } from 'app/components/Buttons';
 import Modal from 'app/components/Modal';
 import controller from 'app/lib/controller';

--- a/src/app/containers/Workspace/SecondaryWidgets.jsx
+++ b/src/app/containers/Workspace/SecondaryWidgets.jsx
@@ -190,7 +190,10 @@ class SecondaryWidgets extends Component {
         .filter(widgetId => {
           // e.g. "webcam" or "webcam:d8e6352f-80a9-475f-a4f5-3e9197a48a23"
           const name = widgetId.split(':')[0];
-          if (name === 'grbl' && !includes(controller.loadedControllers, GRBL)) {
+          if (name === 'grbl' && !includes(controller.loadedControllers, GRBL) && !includes(controller.loadedControllers, GRBLHAL)) {
+            return false;
+          }
+          if (name === 'grblhal' && !includes(controller.loadedControllers, GRBLHAL)) {
             return false;
           }
           if (name === 'marlin' && !includes(controller.loadedControllers, MARLIN)) {

--- a/src/app/containers/Workspace/Widget.jsx
+++ b/src/app/containers/Workspace/Widget.jsx
@@ -5,6 +5,7 @@ import ConnectionWidget from 'app/widgets/Connection';
 import ConsoleWidget from 'app/widgets/Console';
 import GCodeWidget from 'app/widgets/GCode';
 import GrblWidget from 'app/widgets/Grbl';
+import GrblHALWidget from 'app/widgets/GrblHAL';
 import LaserWidget from 'app/widgets/Laser';
 import MacroWidget from 'app/widgets/Macro';
 import MarlinWidget from 'app/widgets/Marlin';
@@ -25,6 +26,7 @@ const getWidgetByName = (name) => {
     'console': ConsoleWidget,
     'gcode': GCodeWidget,
     'grbl': GrblWidget,
+    'grblhal': GrblHALWidget,
     'laser': LaserWidget,
     'macro': MacroWidget,
     'marlin': MarlinWidget,

--- a/src/app/containers/Workspace/WidgetManager/WidgetManager.jsx
+++ b/src/app/containers/Workspace/WidgetManager/WidgetManager.jsx
@@ -51,6 +51,13 @@ class WidgetManager extends PureComponent {
         disabled: false
       },
       {
+        id: 'grblhal',
+        caption: i18n._('grblHAL Widget'),
+        details: i18n._('This widget shows the grblHAL state and provides grblHAL specific features.'),
+        visible: true,
+        disabled: false
+      },
+      {
         id: 'marlin',
         caption: i18n._('Marlin Widget'),
         details: i18n._('This widget shows the Marlin state and provides Marlin specific features.'),
@@ -163,7 +170,10 @@ class WidgetManager extends PureComponent {
       super(props);
 
       this.widgetList = this.widgetList.filter(widgetItem => {
-        if (widgetItem.id === 'grbl' && !includes(controller.loadedControllers, GRBL)) {
+        if (widgetItem.id === 'grbl' && !includes(controller.loadedControllers, GRBL) && !includes(controller.loadedControllers, GRBLHAL)) {
+          return false;
+        }
+        if (widgetItem.id === 'grblhal' && !includes(controller.loadedControllers, GRBLHAL)) {
           return false;
         }
         if (widgetItem.id === 'marlin' && !includes(controller.loadedControllers, MARLIN)) {

--- a/src/app/containers/Workspace/WidgetManager/WidgetManager.jsx
+++ b/src/app/containers/Workspace/WidgetManager/WidgetManager.jsx
@@ -5,7 +5,7 @@ import union from 'lodash/union';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import Modal from 'app/components/Modal';
-import { GRBL, MARLIN, SMOOTHIE, TINYG } from 'app/constants';
+import { GRBL, GRBLHAL, MARLIN, SMOOTHIE, TINYG } from 'app/constants';
 import controller from 'app/lib/controller';
 import i18n from 'app/lib/i18n';
 import store from 'app/store';

--- a/src/app/containers/Workspace/WidgetManager/index.jsx
+++ b/src/app/containers/Workspace/WidgetManager/index.jsx
@@ -3,7 +3,7 @@ import includes from 'lodash/includes';
 import union from 'lodash/union';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { GRBL, MARLIN, SMOOTHIE, TINYG } from 'app/constants';
+import { GRBL, GRBLHAL, MARLIN, SMOOTHIE, TINYG } from 'app/constants';
 import controller from 'app/lib/controller';
 import store from 'app/store';
 import defaultState from 'app/store/defaultState';
@@ -18,7 +18,7 @@ export const getActiveWidgets = () => {
     .map(widgetId => widgetId.split(':')[0]);
   const activeWidgets = union(defaultWidgets, primaryWidgets, secondaryWidgets)
     .filter(widget => {
-      if (widget === 'grbl' && !includes(controller.loadedControllers, GRBL)) {
+      if (widget === 'grbl' && !includes(controller.loadedControllers, GRBL) && !includes(controller.loadedControllers, GRBLHAL)) {
         return false;
       }
       if (widget === 'marlin' && !includes(controller.loadedControllers, MARLIN)) {
@@ -46,7 +46,7 @@ export const getInactiveWidgets = () => {
     .map(widgetId => widgetId.split(':')[0]);
   const inactiveWidgets = difference(allWidgets, defaultWidgets, primaryWidgets, secondaryWidgets)
     .filter(widget => {
-      if (widget === 'grbl' && !includes(controller.loadedControllers, GRBL)) {
+      if (widget === 'grbl' && !includes(controller.loadedControllers, GRBL) && !includes(controller.loadedControllers, GRBLHAL)) {
         return false;
       }
       if (widget === 'marlin' && !includes(controller.loadedControllers, MARLIN)) {

--- a/src/app/containers/Workspace/WidgetManager/index.jsx
+++ b/src/app/containers/Workspace/WidgetManager/index.jsx
@@ -21,6 +21,9 @@ export const getActiveWidgets = () => {
       if (widget === 'grbl' && !includes(controller.loadedControllers, GRBL) && !includes(controller.loadedControllers, GRBLHAL)) {
         return false;
       }
+      if (widget === 'grblhal' && !includes(controller.loadedControllers, GRBLHAL)) {
+        return false;
+      }
       if (widget === 'marlin' && !includes(controller.loadedControllers, MARLIN)) {
         return false;
       }
@@ -47,6 +50,9 @@ export const getInactiveWidgets = () => {
   const inactiveWidgets = difference(allWidgets, defaultWidgets, primaryWidgets, secondaryWidgets)
     .filter(widget => {
       if (widget === 'grbl' && !includes(controller.loadedControllers, GRBL) && !includes(controller.loadedControllers, GRBLHAL)) {
+        return false;
+      }
+      if (widget === 'grblhal' && !includes(controller.loadedControllers, GRBLHAL)) {
         return false;
       }
       if (widget === 'marlin' && !includes(controller.loadedControllers, MARLIN)) {

--- a/src/app/store/defaultState.js
+++ b/src/app/store/defaultState.js
@@ -58,7 +58,7 @@ const defaultState = {
     connection: {
       minimized: false,
       controller: {
-        type: 'Grbl' // Grbl|Marlin|Smoothie|TinyG
+        type: 'Grbl' // Grbl|grblHAL|Marlin|Smoothie|TinyG
       },
       port: '', // will be deprecated in v2
       baudrate: 115200, // will be deprecated in v2

--- a/src/app/store/defaultState.js
+++ b/src/app/store/defaultState.js
@@ -103,6 +103,20 @@ const defaultState = {
         }
       }
     },
+    grblhal: {
+      minimized: false,
+      panel: {
+        queueReports: {
+          expanded: true
+        },
+        statusReports: {
+          expanded: true
+        },
+        modalGroups: {
+          expanded: true
+        }
+      }
+    },
     laser: {
       minimized: false,
       panel: {

--- a/src/app/store/defaultState.js
+++ b/src/app/store/defaultState.js
@@ -16,7 +16,7 @@ const defaultState = {
       primary: {
         show: true,
         widgets: [
-          'connection', 'console', 'grbl', 'marlin', 'smoothie', 'tinyg', 'webcam'
+          'connection', 'console', 'grbl', 'grblhal', 'marlin', 'smoothie', 'tinyg', 'webcam'
         ]
       },
       secondary: {

--- a/src/app/widgets/Axes/index.jsx
+++ b/src/app/widgets/Axes/index.jsx
@@ -28,6 +28,7 @@ import {
   METRIC_STEPS,
   // Grbl
   GRBL,
+  GRBLHAL,
   GRBL_ACTIVE_STATE_IDLE,
   GRBL_ACTIVE_STATE_RUN,
   // Marlin
@@ -745,7 +746,7 @@ class AxesWidget extends PureComponent {
       if (workflow.state === WORKFLOW_STATE_RUNNING) {
         return false;
       }
-      if (!includes([GRBL, MARLIN, SMOOTHIE, TINYG], controllerType)) {
+      if (!includes([GRBL, GRBLHAL, MARLIN, SMOOTHIE, TINYG], controllerType)) {
         return false;
       }
       if (controllerType === GRBL) {

--- a/src/app/widgets/Connection/Connection.jsx
+++ b/src/app/widgets/Connection/Connection.jsx
@@ -12,6 +12,7 @@ import controller from 'app/lib/controller';
 import i18n from 'app/lib/i18n';
 import {
   GRBL,
+  GRBLHAL,
   MARLIN,
   SMOOTHIE,
   TINYG
@@ -115,6 +116,7 @@ class Connection extends PureComponent {
       const enableRTSCTSFlowControl = get(connection, 'serial.rtscts', false);
       const canSelectControllers = (controller.loadedControllers.length > 1);
       const hasGrblController = includes(controller.loadedControllers, GRBL);
+      const hasGrblHALController = includes(controller.loadedControllers, GRBLHAL);
       const hasMarlinController = includes(controller.loadedControllers, MARLIN);
       const hasSmoothieController = includes(controller.loadedControllers, SMOOTHIE);
       const hasTinyGController = includes(controller.loadedControllers, TINYG);
@@ -157,6 +159,22 @@ class Connection extends PureComponent {
                       }}
                     >
                       {GRBL}
+                    </button>
+                  )}
+                  {hasGrblHALController && (
+                    <button
+                      type="button"
+                      className={cx(
+                        'btn',
+                        'btn-default',
+                        { 'btn-select': controllerType === GRBLHAL }
+                      )}
+                      disabled={!canChangeController}
+                      onClick={() => {
+                        actions.changeController(GRBLHAL);
+                      }}
+                    >
+                      {GRBLHAL}
                     </button>
                   )}
                   {hasMarlinController && (

--- a/src/app/widgets/Connection/index.jsx
+++ b/src/app/widgets/Connection/index.jsx
@@ -250,7 +250,7 @@ class ConnectionWidget extends PureComponent {
           alertMessage: '',
           connecting: false,
           connected: true,
-          controllerType: controllerType, // Grbl|Marlin|Smoothie|TinyG
+          controllerType: controllerType, // Grbl|grblHAL|Marlin|Smoothie|TinyG
           port: port,
           baudrate: baudrate,
           ports: ports

--- a/src/app/widgets/GrblHAL/Controller.jsx
+++ b/src/app/widgets/GrblHAL/Controller.jsx
@@ -1,0 +1,79 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Button } from 'app/components/Buttons';
+import Modal from 'app/components/Modal';
+import { Nav, NavItem } from 'app/components/Navs';
+import controller from 'app/lib/controller';
+import i18n from 'app/lib/i18n';
+import styles from './index.styl';
+
+const Controller = (props) => {
+  const { state, actions } = props;
+  const { activeTab = 'state' } = state.modal.params;
+  const height = Math.max(window.innerHeight / 2, 200);
+
+  return (
+    <Modal disableOverlay size="lg" onClose={actions.closeModal}>
+      <Modal.Header>
+        <Modal.Title>
+                    grblHAL
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Nav
+          navStyle="tabs"
+          activeKey={activeTab}
+          onSelect={(eventKey, event) => {
+            actions.updateModalParams({ activeTab: eventKey });
+          }}
+          style={{ marginBottom: 10 }}
+        >
+          <NavItem eventKey="state">{i18n._('Controller State')}</NavItem>
+          <NavItem eventKey="settings">{i18n._('Controller Settings')}</NavItem>
+        </Nav>
+        <div className={styles.navContent} style={{ height: height }}>
+          {activeTab === 'state' && (
+            <pre className={styles.pre}>
+              <code>{JSON.stringify(state.controller.state, null, 4)}</code>
+            </pre>
+          )}
+          {activeTab === 'settings' && (
+            <div>
+              <Button
+                btnSize="xs"
+                btnStyle="flat"
+                style={{
+                  position: 'absolute',
+                  right: 10,
+                  top: 10
+                }}
+                onClick={event => {
+                  controller.writeln('$#'); // Parameters
+                  controller.writeln('$$'); // Settings
+                }}
+              >
+                <i className="fa fa-refresh" />
+                {i18n._('Refresh')}
+              </Button>
+              <pre className={styles.pre}>
+                <code>{JSON.stringify(state.controller.settings, null, 4)}</code>
+              </pre>
+            </div>
+          )}
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button onClick={actions.closeModal}>
+          {i18n._('Close')}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+Controller.propTypes = {
+  state: PropTypes.object,
+  actions: PropTypes.object
+};
+
+export default Controller;

--- a/src/app/widgets/GrblHAL/DigitalReadout.jsx
+++ b/src/app/widgets/GrblHAL/DigitalReadout.jsx
@@ -1,0 +1,42 @@
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styles from './index.styl';
+
+const DigitalReadout = (props) => {
+  const { label, value, children } = props;
+
+  return (
+    <div className={classNames('row', 'no-gutters', styles.dro)}>
+      <div className="col col-xs-1">
+        <div className={styles.droLabel}>{label}</div>
+      </div>
+      <div className="col col-xs-2">
+        <div
+          className={classNames(
+            styles.well,
+            styles.droDisplay
+          )}
+        >
+          {value}
+        </div>
+      </div>
+      <div className="col col-xs-9">
+        <div className={styles.droBtnGroup}>
+          <div className="input-group input-group-sm">
+            <div className="input-group-btn">
+              {children}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+DigitalReadout.propTypes = {
+  label: PropTypes.string,
+  value: PropTypes.string
+};
+
+export default DigitalReadout;

--- a/src/app/widgets/GrblHAL/GrblHAL.jsx
+++ b/src/app/widgets/GrblHAL/GrblHAL.jsx
@@ -1,0 +1,332 @@
+import { ensureArray } from 'ensure-type';
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { ProgressBar } from 'react-bootstrap';
+import mapGCodeToText from 'app/lib/gcode-text';
+import i18n from 'app/lib/i18n';
+import Panel from 'app/components/Panel';
+import Toggler from 'app/components/Toggler';
+import Overrides from './Overrides';
+import styles from './index.styl';
+
+class GrblHAL extends PureComponent {
+    static propTypes = {
+      state: PropTypes.object,
+      actions: PropTypes.object
+    };
+
+    // https://github.com/grbl/grbl/wiki/Interfacing-with-Grbl
+    // Grbl v0.9: BLOCK_BUFFER_SIZE (18), RX_BUFFER_SIZE (128)
+    // Grbl v1.1: BLOCK_BUFFER_SIZE (16), RX_BUFFER_SIZE (128)
+    plannerBufferMax = 0;
+
+    plannerBufferMin = 0;
+
+    receiveBufferMax = 128;
+
+    receiveBufferMin = 0;
+
+    render() {
+      const { state, actions } = this.props;
+      const none = '–';
+      const panel = state.panel;
+      const controllerState = state.controller.state || {};
+      const parserState = _.get(controllerState, 'parserstate', {});
+      const activeState = _.get(controllerState, 'status.activeState') || none;
+      const feedrate = _.get(controllerState, 'status.feedrate', _.get(parserState, 'feedrate', none));
+      const spindle = _.get(controllerState, 'status.spindle', _.get(parserState, 'spindle', none));
+      const tool = _.get(parserState, 'tool', none);
+      const ov = _.get(controllerState, 'status.ov', []);
+      const [ovF = 0, ovR = 0, ovS = 0] = ov;
+      const buf = _.get(controllerState, 'status.buf', {});
+      const modal = _.mapValues(parserState.modal || {}, mapGCodeToText);
+      const receiveBufferStyle = ((rx) => {
+        // danger: 0-7
+        // warning: 8-15
+        // info: >=16
+        rx = Number(rx) || 0;
+        if (rx >= 16) {
+          return 'info';
+        }
+        if (rx >= 8) {
+          return 'warning';
+        }
+        return 'danger';
+      })(buf.rx);
+
+      this.plannerBufferMax = Math.max(this.plannerBufferMax, buf.planner) || this.plannerBufferMax;
+      this.receiveBufferMax = Math.max(this.receiveBufferMax, buf.rx) || this.receiveBufferMax;
+
+      return (
+        <div>
+          <Overrides ovF={ovF} ovS={ovS} ovR={ovR} />
+          {!_.isEmpty(buf) && (
+            <Panel className={styles.panel}>
+              <Panel.Heading className={styles['panel-heading']}>
+                <Toggler
+                  className="clearfix"
+                  onToggle={actions.toggleQueueReports}
+                  title={panel.queueReports.expanded ? i18n._('Hide') : i18n._('Show')}
+                >
+                  <div className="pull-left">{i18n._('Queue Reports')}</div>
+                  <Toggler.Icon
+                    className="pull-right"
+                    expanded={panel.queueReports.expanded}
+                  />
+                </Toggler>
+              </Panel.Heading>
+              {panel.queueReports.expanded && (
+                <Panel.Body>
+                  <div className="row no-gutters">
+                    <div className="col col-xs-4">
+                      <div className={styles.textEllipsis} title={i18n._('Planner Buffer')}>
+                        {i18n._('Planner Buffer')}
+                      </div>
+                    </div>
+                    <div className="col col-xs-8">
+                      <ProgressBar
+                        style={{ marginBottom: 0 }}
+                        bsStyle="info"
+                        min={this.plannerBufferMin}
+                        max={this.plannerBufferMax}
+                        now={buf.planner}
+                        label={(
+                          <span className={styles.progressbarLabel}>
+                            {buf.planner}
+                          </span>
+                        )}
+                      />
+                    </div>
+                  </div>
+                  <div className="row no-gutters">
+                    <div className="col col-xs-4">
+                      <div className={styles.textEllipsis} title={i18n._('Receive Buffer')}>
+                        {i18n._('Receive Buffer')}
+                      </div>
+                    </div>
+                    <div className="col col-xs-8">
+                      <ProgressBar
+                        style={{ marginBottom: 0 }}
+                        bsStyle={receiveBufferStyle}
+                        min={this.receiveBufferMin}
+                        max={this.receiveBufferMax}
+                        now={buf.rx}
+                        label={(
+                          <span className={styles.progressbarLabel}>
+                            {buf.rx}
+                          </span>
+                        )}
+                      />
+                    </div>
+                  </div>
+                </Panel.Body>
+              )}
+            </Panel>
+          )}
+          <Panel className={styles.panel}>
+            <Panel.Heading className={styles['panel-heading']}>
+              <Toggler
+                className="clearfix"
+                onToggle={() => {
+                  actions.toggleStatusReports();
+                }}
+                title={panel.statusReports.expanded ? i18n._('Hide') : i18n._('Show')}
+              >
+                <div className="pull-left">{i18n._('Status Reports')}</div>
+                <Toggler.Icon
+                  className="pull-right"
+                  expanded={panel.statusReports.expanded}
+                />
+              </Toggler>
+            </Panel.Heading>
+            {panel.statusReports.expanded && (
+              <Panel.Body>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('State')}>
+                      {i18n._('State')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well}>
+                      {activeState}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Feed Rate')}>
+                      {i18n._('Feed Rate')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well}>
+                      {feedrate}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Spindle')}>
+                      {i18n._('Spindle')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well}>
+                      {spindle}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Tool Number')}>
+                      {i18n._('Tool Number')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well}>
+                      {tool}
+                    </div>
+                  </div>
+                </div>
+              </Panel.Body>
+            )}
+          </Panel>
+          <Panel className={styles.panel}>
+            <Panel.Heading className={styles['panel-heading']}>
+              <Toggler
+                className="clearfix"
+                onToggle={() => {
+                  actions.toggleModalGroups();
+                }}
+                title={panel.modalGroups.expanded ? i18n._('Hide') : i18n._('Show')}
+              >
+                <div className="pull-left">{i18n._('Modal Groups')}</div>
+                <Toggler.Icon
+                  className="pull-right"
+                  expanded={panel.modalGroups.expanded}
+                />
+              </Toggler>
+            </Panel.Heading>
+            {panel.modalGroups.expanded && (
+              <Panel.Body>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Motion')}>
+                      {i18n._('Motion')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well} title={modal.motion}>
+                      {modal.motion || none}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Coordinate')}>
+                      {i18n._('Coordinate')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well} title={modal.wcs}>
+                      {modal.wcs || none}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Plane')}>
+                      {i18n._('Plane')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well} title={modal.plane}>
+                      {modal.plane || none}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Distance')}>
+                      {i18n._('Distance')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well} title={modal.distance}>
+                      {modal.distance || none}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Feed Rate')}>
+                      {i18n._('Feed Rate')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well} title={modal.feedrate}>
+                      {modal.feedrate || none}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Units')}>
+                      {i18n._('Units')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well} title={modal.units}>
+                      {modal.units || none}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Program')}>
+                      {i18n._('Program')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well} title={modal.program}>
+                      {modal.program || none}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Spindle')}>
+                      {i18n._('Spindle')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well} title={modal.spindle}>
+                      {modal.spindle || none}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Coolant')}>
+                      {i18n._('Coolant')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well}>
+                      {ensureArray(modal.coolant).map(coolant => (
+                        <div title={coolant} key={coolant}>{coolant || none}</div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </Panel.Body>
+            )}
+          </Panel>
+        </div>
+      );
+    }
+}
+
+export default GrblHAL;

--- a/src/app/widgets/GrblHAL/Overrides.jsx
+++ b/src/app/widgets/GrblHAL/Overrides.jsx
@@ -1,0 +1,189 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import Space from 'app/components/Space';
+import RepeatButton from 'app/components/RepeatButton';
+import controller from 'app/lib/controller';
+import DigitalReadout from './DigitalReadout';
+import styles from './index.styl';
+
+const Overrides = (props) => {
+  const { ovF, ovS, ovR } = props;
+
+  if (!ovF && !ovS && !ovR) {
+    return null;
+  }
+
+  return (
+    <div className={styles.overrides}>
+      {!!ovF && (
+        <DigitalReadout label="F" value={ovF + '%'}>
+          <RepeatButton
+            className="btn btn-default"
+            style={{ padding: 5 }}
+            onClick={() => {
+              controller.command('feedOverride', -10);
+            }}
+          >
+            <i className="fa fa-arrow-down" style={{ fontSize: 14 }} />
+            <span style={{ marginLeft: 5 }}>
+                        -10%
+            </span>
+          </RepeatButton>
+          <RepeatButton
+            className="btn btn-default"
+            style={{ padding: 5 }}
+            onClick={() => {
+              controller.command('feedOverride', -1);
+            }}
+          >
+            <i className="fa fa-arrow-down" style={{ fontSize: 10 }} />
+            <span style={{ marginLeft: 5 }}>
+                        -1%
+            </span>
+          </RepeatButton>
+          <RepeatButton
+            className="btn btn-default"
+            style={{ padding: 5 }}
+            onClick={() => {
+              controller.command('feedOverride', 1);
+            }}
+          >
+            <i className="fa fa-arrow-up" style={{ fontSize: 10 }} />
+            <span style={{ marginLeft: 5 }}>
+                        1%
+            </span>
+          </RepeatButton>
+          <RepeatButton
+            className="btn btn-default"
+            style={{ padding: 5 }}
+            onClick={() => {
+              controller.command('feedOverride', 10);
+            }}
+          >
+            <i className="fa fa-arrow-up" style={{ fontSize: 14 }} />
+            <span style={{ marginLeft: 5 }}>
+                        10%
+            </span>
+          </RepeatButton>
+          <button
+            type="button"
+            className="btn btn-default"
+            style={{ padding: 5 }}
+            onClick={() => {
+              controller.command('feedOverride', 0);
+            }}
+          >
+            <i className="fa fa-undo fa-fw" />
+          </button>
+        </DigitalReadout>
+      )}
+      {!!ovS && (
+        <DigitalReadout label="S" value={ovS + '%'}>
+          <RepeatButton
+            className="btn btn-default"
+            style={{ padding: 5 }}
+            onClick={() => {
+              controller.command('spindleOverride', -10);
+            }}
+          >
+            <i className="fa fa-arrow-down" style={{ fontSize: 14 }} />
+            <span style={{ marginLeft: 5 }}>
+                        -10%
+            </span>
+          </RepeatButton>
+          <RepeatButton
+            className="btn btn-default"
+            style={{ padding: 5 }}
+            onClick={() => {
+              controller.command('spindleOverride', -1);
+            }}
+          >
+            <i className="fa fa-arrow-down" style={{ fontSize: 10 }} />
+            <span style={{ marginLeft: 5 }}>
+                        -1%
+            </span>
+          </RepeatButton>
+          <RepeatButton
+            className="btn btn-default"
+            style={{ padding: 5 }}
+            onClick={() => {
+              controller.command('spindleOverride', 1);
+            }}
+          >
+            <i className="fa fa-arrow-up" style={{ fontSize: 10 }} />
+            <span style={{ marginLeft: 5 }}>
+                        1%
+            </span>
+          </RepeatButton>
+          <RepeatButton
+            className="btn btn-default"
+            style={{ padding: 5 }}
+            onClick={() => {
+              controller.command('spindleOverride', 10);
+            }}
+          >
+            <i className="fa fa-arrow-up" style={{ fontSize: 14 }} />
+            <span style={{ marginLeft: 5 }}>
+                        10%
+            </span>
+          </RepeatButton>
+          <button
+            type="button"
+            className="btn btn-default"
+            style={{ padding: 5 }}
+            onClick={() => {
+              controller.command('spindleOverride', 0);
+            }}
+          >
+            <i className="fa fa-undo fa-fw" />
+          </button>
+        </DigitalReadout>
+      )}
+      {!!ovR && (
+        <DigitalReadout label="R" value={ovR + '%'}>
+          <button
+            type="button"
+            className="btn btn-default"
+            onClick={() => {
+              controller.command('rapidOverride', 100);
+            }}
+          >
+            <i className="fa fa-battery-full" />
+            <Space width="8" />
+                    100%
+          </button>
+          <button
+            type="button"
+            className="btn btn-default"
+            onClick={() => {
+              controller.command('rapidOverride', 50);
+            }}
+          >
+            <i className="fa fa-battery-half" />
+            <Space width="8" />
+                    50%
+          </button>
+          <button
+            type="button"
+            className="btn btn-default"
+            onClick={() => {
+              controller.command('rapidOverride', 25);
+            }}
+          >
+            <i className="fa fa-battery-quarter" />
+            <Space width="8" />
+                    25%
+          </button>
+        </DigitalReadout>
+      )}
+    </div>
+  );
+};
+
+Overrides.propTypes = {
+  ovF: PropTypes.number,
+  ovS: PropTypes.number,
+  ovR: PropTypes.number
+};
+
+export default Overrides;

--- a/src/app/widgets/GrblHAL/Settings.jsx
+++ b/src/app/widgets/GrblHAL/Settings.jsx
@@ -2,8 +2,10 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { Button } from 'app/components/Buttons';
 import Modal from 'app/components/Modal';
+import Panel from 'app/components/Panel';
 import controller from 'app/lib/controller';
 import i18n from 'app/lib/i18n';
+import { SETTINGS_INFO, SETTINGS_CATEGORIES } from './settingsInfo';
 import styles from './index.styl';
 
 class Settings extends PureComponent {
@@ -20,6 +22,7 @@ class Settings extends PureComponent {
       values: { ...all },
       all
     };
+    this.fileInputRef = React.createRef();
   }
 
   handleChange = (name, value) => {
@@ -38,46 +41,124 @@ class Settings extends PureComponent {
     this.props.actions.closeModal();
   };
 
-  render() {
-    const { values } = this.state;
-    const { actions } = this.props;
-    return (
-      <Modal size="lg" onClose={actions.closeModal}>
-        <Modal.Header>
-          <Modal.Title>{i18n._('grblHAL Settings')}</Modal.Title>
-        </Modal.Header>
-        <Modal.Body className={styles.settingsModalBody}>
-          <table className={styles.settingsTable}>
-            <thead>
-              <tr>
-                <th>{i18n._('Setting')}</th>
-                <th>{i18n._('Value')}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {Object.keys(values).map(key => (
-                <tr key={key}>
-                  <td>{key}</td>
-                  <td>
-                    <input
-                      type="text"
-                      className="form-control"
-                      value={values[key]}
-                      onChange={e => this.handleChange(key, e.target.value)}
-                    />
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </Modal.Body>
-        <Modal.Footer>
-          <Button onClick={actions.closeModal}>{i18n._('Cancel')}</Button>
-          <Button btnStyle="primary" onClick={this.handleSave}>{i18n._('Save')}</Button>
-        </Modal.Footer>
-      </Modal>
-    );
-  }
+  handleExport = () => {
+    const data = JSON.stringify(this.state.values, null, 2);
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'grblhal-settings.json';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  handleImport = () => {
+    if (this.fileInputRef.current) {
+      this.fileInputRef.current.click();
+    }
+  };
+
+  onImportFile = (event) => {
+    const file = event.target.files[0];
+    if (!file) {
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const obj = JSON.parse(e.target.result);
+        this.setState(state => ({ values: { ...state.values, ...obj } }));
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    reader.readAsText(file);
+    event.target.value = '';
+  };
+
+    renderInput(name, info) {
+      const value = this.state.values[name];
+      if (info && info.units === 'boolean') {
+        return (
+          <input
+            type="checkbox"
+            checked={String(value) === '1' || value === true}
+            onChange={e => this.handleChange(name, e.target.checked ? '1' : '0')}
+          />
+        );
+      }
+      return (
+        <input
+          type="text"
+          className="form-control"
+          value={value}
+          onChange={e => this.handleChange(name, e.target.value)}
+        />
+      );
+    }
+
+    render() {
+      const { values } = this.state;
+      const { actions } = this.props;
+
+      const infoMap = {};
+      SETTINGS_INFO.forEach(item => {
+        infoMap[item.setting] = item;
+      });
+
+      return (
+        <Modal size="lg" onClose={actions.closeModal}>
+          <Modal.Header>
+            <Modal.Title>{i18n._('grblHAL Settings')}</Modal.Title>
+          </Modal.Header>
+          <Modal.Body className={styles.settingsModalBody}>
+            {Object.keys(SETTINGS_CATEGORIES).map(section => (
+              <Panel className={styles.settingsSection} key={section}>
+                <Panel.Heading>{section}</Panel.Heading>
+                <Panel.Body>
+                  <table className={styles.settingsTable}>
+                    <tbody>
+                      {SETTINGS_CATEGORIES[section].filter(key => key in values).map(key => (
+                        <tr key={key}>
+                          <td>{infoMap[key]?.message || key}</td>
+                          <td>{this.renderInput(key, infoMap[key])}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </Panel.Body>
+              </Panel>
+            ))}
+            {Object.keys(values).filter(key => !infoMap[key]).length > 0 && (
+              <Panel className={styles.settingsSection}>
+                <Panel.Heading>Other</Panel.Heading>
+                <Panel.Body>
+                  <table className={styles.settingsTable}>
+                    <tbody>
+                      {Object.keys(values).filter(key => !infoMap[key]).map(key => (
+                        <tr key={key}>
+                          <td>{key}</td>
+                          <td>{this.renderInput(key, {})}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </Panel.Body>
+              </Panel>
+            )}
+            <input type="file" style={{ display: 'none' }} ref={this.fileInputRef} onChange={this.onImportFile} />
+          </Modal.Body>
+          <Modal.Footer>
+            <Button onClick={this.handleImport}>{i18n._('Import')}</Button>
+            <Button onClick={this.handleExport}>{i18n._('Export')}</Button>
+            <Button onClick={actions.closeModal}>{i18n._('Cancel')}</Button>
+            <Button btnStyle="primary" onClick={this.handleSave}>{i18n._('Save')}</Button>
+          </Modal.Footer>
+        </Modal>
+      );
+    }
 }
 
 export default Settings;

--- a/src/app/widgets/GrblHAL/Settings.jsx
+++ b/src/app/widgets/GrblHAL/Settings.jsx
@@ -1,0 +1,70 @@
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import { Button } from 'app/components/Buttons';
+import Modal from 'app/components/Modal';
+import controller from 'app/lib/controller';
+import i18n from 'app/lib/i18n';
+import styles from './index.styl';
+
+const Settings = ({ state, actions }) => {
+  const settings = state.controller.settings || {};
+  const all = settings.settings || {};
+  const [values, setValues] = useState(() => ({ ...all }));
+
+  const handleChange = (name, value) => {
+    setValues(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSave = () => {
+    Object.keys(values).forEach(key => {
+      if (String(all[key]) !== String(values[key])) {
+        controller.writeln(`${key}=${values[key]}`);
+      }
+    });
+    actions.closeModal();
+  };
+
+  return (
+    <Modal size="lg" onClose={actions.closeModal}>
+      <Modal.Header>
+        <Modal.Title>{i18n._('grblHAL Settings')}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body className={styles.settingsModalBody}>
+        <table className={styles.settingsTable}>
+          <thead>
+            <tr>
+              <th>{i18n._('Setting')}</th>
+              <th>{i18n._('Value')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Object.keys(values).map(key => (
+              <tr key={key}>
+                <td>{key}</td>
+                <td>
+                  <input
+                    type="text"
+                    className="form-control"
+                    value={values[key]}
+                    onChange={e => handleChange(key, e.target.value)}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button onClick={actions.closeModal}>{i18n._('Cancel')}</Button>
+        <Button btnStyle="primary" onClick={handleSave}>{i18n._('Save')}</Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+Settings.propTypes = {
+  state: PropTypes.object,
+  actions: PropTypes.object
+};
+
+export default Settings;

--- a/src/app/widgets/GrblHAL/Settings.jsx
+++ b/src/app/widgets/GrblHAL/Settings.jsx
@@ -1,70 +1,83 @@
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { PureComponent } from 'react';
 import { Button } from 'app/components/Buttons';
 import Modal from 'app/components/Modal';
 import controller from 'app/lib/controller';
 import i18n from 'app/lib/i18n';
 import styles from './index.styl';
 
-const Settings = ({ state, actions }) => {
-  const settings = state.controller.settings || {};
-  const all = settings.settings || {};
-  const [values, setValues] = useState(() => ({ ...all }));
-
-  const handleChange = (name, value) => {
-    setValues(prev => ({ ...prev, [name]: value }));
+class Settings extends PureComponent {
+  static propTypes = {
+    state: PropTypes.object,
+    actions: PropTypes.object
   };
 
-  const handleSave = () => {
+  constructor(props) {
+    super(props);
+    const settings = props.state.controller.settings || {};
+    const all = settings.settings || {};
+    this.state = {
+      values: { ...all },
+      all
+    };
+  }
+
+  handleChange = (name, value) => {
+    this.setState(state => ({
+      values: { ...state.values, [name]: value }
+    }));
+  };
+
+  handleSave = () => {
+    const { values, all } = this.state;
     Object.keys(values).forEach(key => {
       if (String(all[key]) !== String(values[key])) {
         controller.writeln(`${key}=${values[key]}`);
       }
     });
-    actions.closeModal();
+    this.props.actions.closeModal();
   };
 
-  return (
-    <Modal size="lg" onClose={actions.closeModal}>
-      <Modal.Header>
-        <Modal.Title>{i18n._('grblHAL Settings')}</Modal.Title>
-      </Modal.Header>
-      <Modal.Body className={styles.settingsModalBody}>
-        <table className={styles.settingsTable}>
-          <thead>
-            <tr>
-              <th>{i18n._('Setting')}</th>
-              <th>{i18n._('Value')}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {Object.keys(values).map(key => (
-              <tr key={key}>
-                <td>{key}</td>
-                <td>
-                  <input
-                    type="text"
-                    className="form-control"
-                    value={values[key]}
-                    onChange={e => handleChange(key, e.target.value)}
-                  />
-                </td>
+  render() {
+    const { values } = this.state;
+    const { actions } = this.props;
+    return (
+      <Modal size="lg" onClose={actions.closeModal}>
+        <Modal.Header>
+          <Modal.Title>{i18n._('grblHAL Settings')}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body className={styles.settingsModalBody}>
+          <table className={styles.settingsTable}>
+            <thead>
+              <tr>
+                <th>{i18n._('Setting')}</th>
+                <th>{i18n._('Value')}</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </Modal.Body>
-      <Modal.Footer>
-        <Button onClick={actions.closeModal}>{i18n._('Cancel')}</Button>
-        <Button btnStyle="primary" onClick={handleSave}>{i18n._('Save')}</Button>
-      </Modal.Footer>
-    </Modal>
-  );
-};
-
-Settings.propTypes = {
-  state: PropTypes.object,
-  actions: PropTypes.object
-};
+            </thead>
+            <tbody>
+              {Object.keys(values).map(key => (
+                <tr key={key}>
+                  <td>{key}</td>
+                  <td>
+                    <input
+                      type="text"
+                      className="form-control"
+                      value={values[key]}
+                      onChange={e => this.handleChange(key, e.target.value)}
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={actions.closeModal}>{i18n._('Cancel')}</Button>
+          <Button btnStyle="primary" onClick={this.handleSave}>{i18n._('Save')}</Button>
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+}
 
 export default Settings;

--- a/src/app/widgets/GrblHAL/Settings.jsx
+++ b/src/app/widgets/GrblHAL/Settings.jsx
@@ -22,7 +22,8 @@ class Settings extends PureComponent {
       values: { ...all },
       all
     };
-    this.fileInputRef = React.createRef();
+    // React 15 does not support createRef(), use a callback ref instead
+    this.fileInputRef = null;
   }
 
   handleChange = (name, value) => {
@@ -55,8 +56,8 @@ class Settings extends PureComponent {
   };
 
   handleImport = () => {
-    if (this.fileInputRef.current) {
-      this.fileInputRef.current.click();
+    if (this.fileInputRef) {
+      this.fileInputRef.click();
     }
   };
 
@@ -148,7 +149,14 @@ class Settings extends PureComponent {
                 </Panel.Body>
               </Panel>
             )}
-            <input type="file" style={{ display: 'none' }} ref={this.fileInputRef} onChange={this.onImportFile} />
+            <input
+              type="file"
+              style={{ display: 'none' }}
+              ref={(el) => {
+                this.fileInputRef = el;
+              }}
+              onChange={this.onImportFile}
+            />
           </Modal.Body>
           <Modal.Footer>
             <Button onClick={this.handleImport}>{i18n._('Import')}</Button>

--- a/src/app/widgets/GrblHAL/constants.js
+++ b/src/app/widgets/GrblHAL/constants.js
@@ -1,0 +1,9 @@
+import constants from 'namespace-constants';
+
+export const {
+  MODAL_NONE,
+  MODAL_CONTROLLER
+} = constants('widgets/GrblHAL', [
+  'MODAL_NONE',
+  'MODAL_CONTROLLER'
+]);

--- a/src/app/widgets/GrblHAL/constants.js
+++ b/src/app/widgets/GrblHAL/constants.js
@@ -2,8 +2,10 @@ import constants from 'namespace-constants';
 
 export const {
   MODAL_NONE,
-  MODAL_CONTROLLER
+  MODAL_CONTROLLER,
+  MODAL_SETTINGS
 } = constants('widgets/GrblHAL', [
   'MODAL_NONE',
-  'MODAL_CONTROLLER'
+  'MODAL_CONTROLLER',
+  'MODAL_SETTINGS'
 ]);

--- a/src/app/widgets/GrblHAL/index.jsx
+++ b/src/app/widgets/GrblHAL/index.jsx
@@ -1,0 +1,417 @@
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import Space from 'app/components/Space';
+import Widget from 'app/components/Widget';
+import i18n from 'app/lib/i18n';
+import controller from 'app/lib/controller';
+import WidgetConfig from '../WidgetConfig';
+import GrblHAL from './GrblHAL';
+import Controller from './Controller';
+import {
+  GRBLHAL
+} from '../../constants';
+import {
+  MODAL_NONE,
+  MODAL_CONTROLLER
+} from './constants';
+import styles from './index.styl';
+
+class GrblHALWidget extends PureComponent {
+    static propTypes = {
+      widgetId: PropTypes.string.isRequired,
+      onFork: PropTypes.func.isRequired,
+      onRemove: PropTypes.func.isRequired,
+      sortable: PropTypes.object
+    };
+
+    // Public methods
+    collapse = () => {
+      this.setState({ minimized: true });
+    };
+
+    expand = () => {
+      this.setState({ minimized: false });
+    };
+
+    config = new WidgetConfig(this.props.widgetId);
+
+    state = this.getInitialState();
+
+    actions = {
+      toggleFullscreen: () => {
+        const { minimized, isFullscreen } = this.state;
+        this.setState({
+          minimized: isFullscreen ? minimized : false,
+          isFullscreen: !isFullscreen
+        });
+      },
+      toggleMinimized: () => {
+        const { minimized } = this.state;
+        this.setState({ minimized: !minimized });
+      },
+      openModal: (name = MODAL_NONE, params = {}) => {
+        this.setState({
+          modal: {
+            name: name,
+            params: params
+          }
+        });
+      },
+      closeModal: () => {
+        this.setState({
+          modal: {
+            name: MODAL_NONE,
+            params: {}
+          }
+        });
+      },
+      updateModalParams: (params = {}) => {
+        this.setState({
+          modal: {
+            ...this.state.modal,
+            params: {
+              ...this.state.modal.params,
+              ...params
+            }
+          }
+        });
+      },
+      toggleQueueReports: () => {
+        const expanded = this.state.panel.queueReports.expanded;
+
+        this.setState({
+          panel: {
+            ...this.state.panel,
+            queueReports: {
+              ...this.state.panel.queueReports,
+              expanded: !expanded
+            }
+          }
+        });
+      },
+      toggleStatusReports: () => {
+        const expanded = this.state.panel.statusReports.expanded;
+
+        this.setState({
+          panel: {
+            ...this.state.panel,
+            statusReports: {
+              ...this.state.panel.statusReports,
+              expanded: !expanded
+            }
+          }
+        });
+      },
+      toggleModalGroups: () => {
+        const expanded = this.state.panel.modalGroups.expanded;
+
+        this.setState({
+          panel: {
+            ...this.state.panel,
+            modalGroups: {
+              ...this.state.panel.modalGroups,
+              expanded: !expanded
+            }
+          }
+        });
+      }
+    };
+
+    controllerEvents = {
+      'serialport:open': (options) => {
+        const { port, controllerType } = options;
+        this.setState({
+          isReady: controllerType === GRBLHAL,
+          port: port
+        });
+      },
+      'serialport:close': (options) => {
+        const initialState = this.getInitialState();
+        this.setState({ ...initialState });
+      },
+      'controller:settings': (type, controllerSettings) => {
+        if (type === GRBLHAL) {
+          this.setState(state => ({
+            controller: {
+              ...state.controller,
+              type: type,
+              settings: controllerSettings
+            }
+          }));
+        }
+      },
+      'controller:state': (type, controllerState) => {
+        if (type === GRBLHAL) {
+          this.setState(state => ({
+            controller: {
+              ...state.controller,
+              type: type,
+              state: controllerState
+            }
+          }));
+        }
+      }
+    };
+
+    componentDidMount() {
+      this.addControllerEvents();
+    }
+
+    componentWillUnmount() {
+      this.removeControllerEvents();
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+      const {
+        minimized,
+        panel
+      } = this.state;
+
+      this.config.set('minimized', minimized);
+      this.config.set('panel.queueReports.expanded', panel.queueReports.expanded);
+      this.config.set('panel.statusReports.expanded', panel.statusReports.expanded);
+      this.config.set('panel.modalGroups.expanded', panel.modalGroups.expanded);
+    }
+
+    getInitialState() {
+      return {
+        minimized: this.config.get('minimized', false),
+        isFullscreen: false,
+        isReady: (controller.loadedControllers.length === 1) || (controller.type === GRBLHAL),
+        canClick: true, // Defaults to true
+        port: controller.port,
+        controller: {
+          type: controller.type,
+          settings: controller.settings,
+          state: controller.state
+        },
+        modal: {
+          name: MODAL_NONE,
+          params: {}
+        },
+        panel: {
+          queueReports: {
+            expanded: this.config.get('panel.queueReports.expanded')
+          },
+          statusReports: {
+            expanded: this.config.get('panel.statusReports.expanded')
+          },
+          modalGroups: {
+            expanded: this.config.get('panel.modalGroups.expanded')
+          }
+        }
+      };
+    }
+
+    addControllerEvents() {
+      Object.keys(this.controllerEvents).forEach(eventName => {
+        const callback = this.controllerEvents[eventName];
+        controller.addListener(eventName, callback);
+      });
+    }
+
+    removeControllerEvents() {
+      Object.keys(this.controllerEvents).forEach(eventName => {
+        const callback = this.controllerEvents[eventName];
+        controller.removeListener(eventName, callback);
+      });
+    }
+
+    canClick() {
+      const { port } = this.state;
+      const { type } = this.state.controller;
+
+      if (!port) {
+        return false;
+      }
+      if (type !== GRBLHAL) {
+        return false;
+      }
+
+      return true;
+    }
+
+    render() {
+      const { widgetId } = this.props;
+      const { minimized, isFullscreen, isReady } = this.state;
+      const isForkedWidget = widgetId.match(/\w+:[\w\-]+/);
+      const state = {
+        ...this.state,
+        canClick: this.canClick()
+      };
+      const actions = {
+        ...this.actions
+      };
+
+      return (
+        <Widget fullscreen={isFullscreen}>
+          <Widget.Header>
+            <Widget.Title>
+              <Widget.Sortable className={this.props.sortable.handleClassName}>
+                <i className="fa fa-bars" />
+                <Space width="8" />
+              </Widget.Sortable>
+              {isForkedWidget &&
+                <i className="fa fa-code-fork" style={{ marginRight: 5 }} />
+              }
+                        GrblHAL
+            </Widget.Title>
+            <Widget.Controls className={this.props.sortable.filterClassName}>
+              {isReady && (
+                <Widget.Button
+                  onClick={(event) => {
+                    actions.openModal(MODAL_CONTROLLER);
+                  }}
+                >
+                  <i className="fa fa-info" />
+                </Widget.Button>
+              )}
+              {isReady && (
+                <Widget.DropdownButton
+                  toggle={<i className="fa fa-th-large" />}
+                >
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.write('?')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('Status Report (?)')}
+                  </Widget.DropdownMenuItem>
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.writeln('$C')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('Check G-code Mode ($C)')}
+                  </Widget.DropdownMenuItem>
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.command('homing')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('Homing ($H)')}
+                  </Widget.DropdownMenuItem>
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.command('unlock')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('Kill Alarm Lock ($X)')}
+                  </Widget.DropdownMenuItem>
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.command('sleep')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('Sleep ($SLP)')}
+                  </Widget.DropdownMenuItem>
+                  <Widget.DropdownMenuItem divider />
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.writeln('$')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('Help ($)')}
+                  </Widget.DropdownMenuItem>
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.writeln('$$')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('Settings ($$)')}
+                  </Widget.DropdownMenuItem>
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.writeln('$#')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('View G-code Parameters ($#)')}
+                  </Widget.DropdownMenuItem>
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.writeln('$G')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('View G-code Parser State ($G)')}
+                  </Widget.DropdownMenuItem>
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.writeln('$I')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('View Build Info ($I)')}
+                  </Widget.DropdownMenuItem>
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.writeln('$N')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('View Startup Blocks ($N)')}
+                  </Widget.DropdownMenuItem>
+                </Widget.DropdownButton>
+              )}
+              {isReady && (
+                <Widget.Button
+                  disabled={isFullscreen}
+                  title={minimized ? i18n._('Expand') : i18n._('Collapse')}
+                  onClick={actions.toggleMinimized}
+                >
+                  <i
+                    className={classNames(
+                      'fa',
+                      { 'fa-chevron-up': !minimized },
+                      { 'fa-chevron-down': minimized }
+                    )}
+                  />
+                </Widget.Button>
+              )}
+              <Widget.DropdownButton
+                title={i18n._('More')}
+                toggle={<i className="fa fa-ellipsis-v" />}
+                onSelect={(eventKey) => {
+                  if (eventKey === 'fullscreen') {
+                    actions.toggleFullscreen();
+                  } else if (eventKey === 'fork') {
+                    this.props.onFork();
+                  } else if (eventKey === 'remove') {
+                    this.props.onRemove();
+                  }
+                }}
+              >
+                <Widget.DropdownMenuItem eventKey="fullscreen" disabled={!isReady}>
+                  <i
+                    className={classNames(
+                      'fa',
+                      'fa-fw',
+                      { 'fa-expand': !isFullscreen },
+                      { 'fa-compress': isFullscreen }
+                    )}
+                  />
+                  <Space width="4" />
+                  {!isFullscreen ? i18n._('Enter Full Screen') : i18n._('Exit Full Screen')}
+                </Widget.DropdownMenuItem>
+                <Widget.DropdownMenuItem eventKey="fork">
+                  <i className="fa fa-fw fa-code-fork" />
+                  <Space width="4" />
+                  {i18n._('Fork Widget')}
+                </Widget.DropdownMenuItem>
+                <Widget.DropdownMenuItem eventKey="remove">
+                  <i className="fa fa-fw fa-times" />
+                  <Space width="4" />
+                  {i18n._('Remove Widget')}
+                </Widget.DropdownMenuItem>
+              </Widget.DropdownButton>
+            </Widget.Controls>
+          </Widget.Header>
+          {isReady && (
+            <Widget.Content
+              className={classNames(
+                styles['widget-content'],
+                { [styles.hidden]: minimized }
+              )}
+            >
+              {state.modal.name === MODAL_CONTROLLER &&
+                <Controller state={state} actions={actions} />
+              }
+              <GrblHAL
+                state={state}
+                actions={actions}
+              />
+            </Widget.Content>
+          )}
+        </Widget>
+      );
+    }
+}
+
+export default GrblHALWidget;

--- a/src/app/widgets/GrblHAL/index.jsx
+++ b/src/app/widgets/GrblHAL/index.jsx
@@ -8,12 +8,14 @@ import controller from 'app/lib/controller';
 import WidgetConfig from '../WidgetConfig';
 import GrblHAL from './GrblHAL';
 import Controller from './Controller';
+import Settings from './Settings';
 import {
   GRBLHAL
 } from '../../constants';
 import {
   MODAL_NONE,
-  MODAL_CONTROLLER
+  MODAL_CONTROLLER,
+  MODAL_SETTINGS
 } from './constants';
 import styles from './index.styl';
 
@@ -268,6 +270,13 @@ class GrblHALWidget extends PureComponent {
                 </Widget.Button>
               )}
               {isReady && (
+                <Widget.Button
+                  onClick={() => actions.openModal(MODAL_SETTINGS)}
+                >
+                  <i className="fa fa-sliders" />
+                </Widget.Button>
+              )}
+              {isReady && (
                 <Widget.DropdownButton
                   toggle={<i className="fa fa-th-large" />}
                 >
@@ -402,6 +411,9 @@ class GrblHALWidget extends PureComponent {
             >
               {state.modal.name === MODAL_CONTROLLER &&
                 <Controller state={state} actions={actions} />
+              }
+              {state.modal.name === MODAL_SETTINGS &&
+                <Settings state={state} actions={actions} />
               }
               <GrblHAL
                 state={state}

--- a/src/app/widgets/GrblHAL/index.styl
+++ b/src/app/widgets/GrblHAL/index.styl
@@ -1,0 +1,104 @@
+.widget-content {
+    position: relative;
+    padding: 10px;
+
+    &.hidden {
+        display: none;
+    }
+}
+
+.overrides {
+    margin-bottom: 10px;
+
+    .dro {
+        margin-bottom: 10px;
+    }
+
+    .dro-label,
+    .dro-display,
+    .dro-btn-group {
+        height: 30px;
+    }
+    .dro-label {
+        font-size: 24px;
+        line-height: initial;
+        text-align: left;
+    }
+    .dro-display {
+        padding: 4px 6px;
+        text-align: right;
+        font-size: 14px;
+        text-overflow: initial;
+        margin-right: 5px;
+    }
+    .dro-btn-group {
+        margin-left: 5px;
+    }
+    .dro-btn {
+        padding: 5px 5px;
+    }
+}
+
+.panel {
+    margin-bottom: 10px;
+
+    &:last-child {
+        margin-bottom: 0;
+    }
+
+    :global {
+        .row {
+            margin-bottom: 5px;
+        }
+        .row:last-child {
+            margin-bottom: 0;
+        }
+    }
+}
+.panel-heading:hover {
+    background-color: rgba(0, 0, 0, .05);
+}
+
+.progressbar-label {
+    color: #222;
+    padding: 0 10px;
+}
+
+.text-ellipsis {
+    white-space: nowrap;
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.well {
+    min-height: 22px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    background-color: #f5f5f5;
+    border: 1px solid #e3e3e3;
+    border-radius: 3px;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, .05);
+    margin-bottom: 0;
+    padding: 0 5px;
+}
+
+.nav-content {
+    position: relative;
+    overflow-y: auto;
+    background: #000;
+    color: #fff;
+    border: 1px solid #ddd;
+
+    .pre {
+        display: block;
+        font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif;
+        color: inherit;
+        background: inherit;
+        border: 0;
+        border-radius: 0;
+        margin: 0;
+        padding: 10px;
+    }
+}

--- a/src/app/widgets/GrblHAL/index.styl
+++ b/src/app/widgets/GrblHAL/index.styl
@@ -118,3 +118,7 @@
     max-height: 60vh;
     overflow-y: auto;
 }
+
+.settingsSection {
+    margin-bottom: 10px;
+}

--- a/src/app/widgets/GrblHAL/index.styl
+++ b/src/app/widgets/GrblHAL/index.styl
@@ -102,3 +102,19 @@
         padding: 10px;
     }
 }
+
+.settingsTable {
+    width: 100%;
+    th {
+        text-align: left;
+        padding: 4px;
+    }
+    td {
+        padding: 4px;
+    }
+}
+
+.settingsModalBody {
+    max-height: 60vh;
+    overflow-y: auto;
+}

--- a/src/app/widgets/GrblHAL/settingsInfo.js
+++ b/src/app/widgets/GrblHAL/settingsInfo.js
@@ -1,0 +1,43 @@
+export const SETTINGS_INFO = [
+  { setting: '$0', message: 'Step pulse time', units: 'microseconds' },
+  { setting: '$1', message: 'Step idle delay', units: 'milliseconds' },
+  { setting: '$2', message: 'Step pulse invert', units: 'mask' },
+  { setting: '$3', message: 'Step direction invert', units: 'mask' },
+  { setting: '$4', message: 'Invert step enable pin', units: 'boolean' },
+  { setting: '$5', message: 'Invert limit pins', units: 'boolean' },
+  { setting: '$6', message: 'Invert probe pin', units: 'boolean' },
+  { setting: '$10', message: 'Status report options', units: 'mask' },
+  { setting: '$11', message: 'Junction deviation', units: 'millimeters' },
+  { setting: '$12', message: 'Arc tolerance', units: 'millimeters' },
+  { setting: '$13', message: 'Report in inches', units: 'boolean' },
+  { setting: '$20', message: 'Soft limits enable', units: 'boolean' },
+  { setting: '$21', message: 'Hard limits enable', units: 'boolean' },
+  { setting: '$22', message: 'Homing cycle enable', units: 'boolean' },
+  { setting: '$23', message: 'Homing direction invert', units: 'mask' },
+  { setting: '$24', message: 'Homing locate feed rate', units: 'mm/min' },
+  { setting: '$25', message: 'Homing search seek rate', units: 'mm/min' },
+  { setting: '$26', message: 'Homing switch debounce delay', units: 'milliseconds' },
+  { setting: '$27', message: 'Homing switch pull-off distance', units: 'millimeters' },
+  { setting: '$30', message: 'Maximum spindle speed', units: 'RPM' },
+  { setting: '$31', message: 'Minimum spindle speed', units: 'RPM' },
+  { setting: '$32', message: 'Laser-mode enable', units: 'boolean' },
+  { setting: '$100', message: 'X-axis travel resolution', units: 'step/mm' },
+  { setting: '$101', message: 'Y-axis travel resolution', units: 'step/mm' },
+  { setting: '$102', message: 'Z-axis travel resolution', units: 'step/mm' },
+  { setting: '$110', message: 'X-axis maximum rate', units: 'mm/min' },
+  { setting: '$111', message: 'Y-axis maximum rate', units: 'mm/min' },
+  { setting: '$112', message: 'Z-axis maximum rate', units: 'mm/min' },
+  { setting: '$120', message: 'X-axis acceleration', units: 'mm/sec^2' },
+  { setting: '$121', message: 'Y-axis acceleration', units: 'mm/sec^2' },
+  { setting: '$122', message: 'Z-axis acceleration', units: 'mm/sec^2' },
+  { setting: '$130', message: 'X-axis maximum travel', units: 'millimeters' },
+  { setting: '$131', message: 'Y-axis maximum travel', units: 'millimeters' },
+  { setting: '$132', message: 'Z-axis maximum travel', units: 'millimeters' }
+];
+
+export const SETTINGS_CATEGORIES = {
+  'General': ['$0', '$1', '$2', '$3', '$4', '$5', '$6', '$10', '$11', '$12', '$13'],
+  'Homing & Limits': ['$20', '$21', '$22', '$23', '$24', '$25', '$26', '$27'],
+  'Spindle/Laser': ['$30', '$31', '$32'],
+  'Axes': ['$100', '$101', '$102', '$110', '$111', '$112', '$120', '$121', '$122', '$130', '$131', '$132']
+};

--- a/src/app/widgets/Laser/index.jsx
+++ b/src/app/widgets/Laser/index.jsx
@@ -13,6 +13,7 @@ import Laser from './Laser';
 import {
   // Grbl
   GRBL,
+  GRBLHAL,
   // Marlin
   MARLIN,
   // Smoothie
@@ -224,7 +225,7 @@ class LaserWidget extends PureComponent {
       if (!port) {
         return false;
       }
-      if (!includes([GRBL, MARLIN, SMOOTHIE, TINYG], controllerType)) {
+      if (!includes([GRBL, GRBLHAL, MARLIN, SMOOTHIE, TINYG], controllerType)) {
         return false;
       }
       if (!(isNumber(test.power) && isNumber(test.duration) && isNumber(test.maxS))) {

--- a/src/app/widgets/Macro/index.jsx
+++ b/src/app/widgets/Macro/index.jsx
@@ -17,6 +17,7 @@ import RunMacro from './RunMacro';
 import {
   // Grbl
   GRBL,
+  GRBLHAL,
   GRBL_ACTIVE_STATE_IDLE,
   GRBL_ACTIVE_STATE_RUN,
   // Marlin
@@ -285,7 +286,7 @@ class MacroWidget extends PureComponent {
       if (workflow.state === WORKFLOW_STATE_RUNNING) {
         return false;
       }
-      if (!includes([GRBL, MARLIN, SMOOTHIE, TINYG], controllerType)) {
+      if (!includes([GRBL, GRBLHAL, MARLIN, SMOOTHIE, TINYG], controllerType)) {
         return false;
       }
       if (controllerType === GRBL) {

--- a/src/app/widgets/Probe/index.jsx
+++ b/src/app/widgets/Probe/index.jsx
@@ -18,6 +18,7 @@ import {
   METRIC_UNITS,
   // Grbl
   GRBL,
+  GRBLHAL,
   GRBL_ACTIVE_STATE_IDLE,
   // Marlin
   MARLIN,
@@ -421,7 +422,7 @@ class ProbeWidget extends PureComponent {
       if (workflow.state !== WORKFLOW_STATE_IDLE) {
         return false;
       }
-      if (!includes([GRBL, MARLIN, SMOOTHIE, TINYG], controllerType)) {
+      if (!includes([GRBL, GRBLHAL, MARLIN, SMOOTHIE, TINYG], controllerType)) {
         return false;
       }
       if (controllerType === GRBL) {

--- a/src/app/widgets/Spindle/index.jsx
+++ b/src/app/widgets/Spindle/index.jsx
@@ -12,6 +12,7 @@ import Spindle from './Spindle';
 import {
   // Grbl
   GRBL,
+  GRBLHAL,
   GRBL_ACTIVE_STATE_IDLE,
   GRBL_ACTIVE_STATE_HOLD,
   // Marlin
@@ -220,7 +221,7 @@ class SpindleWidget extends PureComponent {
       if (workflow.state === WORKFLOW_STATE_RUNNING) {
         return false;
       }
-      if (!includes([GRBL, MARLIN, SMOOTHIE, TINYG], controllerType)) {
+      if (!includes([GRBL, GRBLHAL, MARLIN, SMOOTHIE, TINYG], controllerType)) {
         return false;
       }
       if (controllerType === GRBL) {

--- a/src/app/widgets/Tool/index.jsx
+++ b/src/app/widgets/Tool/index.jsx
@@ -22,6 +22,7 @@ import {
   METRIC_UNITS,
   // Grbl
   GRBL,
+  GRBLHAL,
   // Marlin
   MARLIN,
   // Smoothie
@@ -504,7 +505,7 @@ class ToolWidget extends PureComponent {
     if (!port) {
       return false;
     }
-    if (!includes([GRBL, MARLIN, SMOOTHIE, TINYG], controllerType)) {
+    if (!includes([GRBL, GRBLHAL, MARLIN, SMOOTHIE, TINYG], controllerType)) {
       return false;
     }
     return true;

--- a/src/app/widgets/Visualizer/index.jsx
+++ b/src/app/widgets/Visualizer/index.jsx
@@ -34,6 +34,7 @@ import {
   METRIC_UNITS,
   // Grbl
   GRBL,
+  GRBLHAL,
   GRBL_ACTIVE_STATE_RUN,
   // Marlin
   MARLIN,
@@ -981,7 +982,7 @@ class VisualizerWidget extends PureComponent {
       if (!objects.cuttingTool.visible) {
         return false;
       }
-      if (!includes([GRBL, MARLIN, SMOOTHIE, TINYG], controllerType)) {
+      if (!includes([GRBL, GRBLHAL, MARLIN, SMOOTHIE, TINYG], controllerType)) {
         return false;
       }
       if (controllerType === GRBL) {

--- a/src/server-cli.js
+++ b/src/server-cli.js
@@ -43,7 +43,7 @@ const parseMountPoint = (val, acc) => {
 const parseController = (val) => {
   val = val ? (val + '').toLowerCase() : '';
 
-  if (['grbl', 'marlin', 'smoothie', 'tinyg', 'g2core'].includes(val)) {
+  if (['grbl', 'grblhal', 'marlin', 'smoothie', 'tinyg', 'g2core'].includes(val)) {
     return val;
   } else {
     return '';
@@ -65,7 +65,7 @@ program
   .option('-w, --watch-directory <path>', 'Watch a directory for changes')
   .option('--access-token-lifetime <lifetime>', 'Access token lifetime in seconds or a time span string (default: 30d)')
   .option('--allow-remote-access', 'Allow remote access to the server (default: false)')
-  .option('--controller <type>', 'Specify CNC controller: Grbl|Marlin|Smoothie|TinyG|g2core (default: \'\')', parseController, '');
+  .option('--controller <type>', 'Specify CNC controller: Grbl|grblHAL|Marlin|Smoothie|TinyG|g2core (default: \'\')', parseController, '');
 
 program.on('--help', () => {
   console.log('');

--- a/src/server/controllers/Grbl/GrblController.js
+++ b/src/server/controllers/Grbl/GrblController.js
@@ -148,11 +148,12 @@ class GrblController {
     // Workflow
     workflow = null;
 
-    constructor(engine, options) {
+    constructor(engine, options = {}) {
       if (!engine) {
         throw new Error('engine must be specified');
       }
       this.engine = engine;
+      this.type = options.type || GRBL;
 
       const { port, baudrate, rtscts, pin } = { ...options };
       this.options = {

--- a/src/server/controllers/Grbl/GrblController.js
+++ b/src/server/controllers/Grbl/GrblController.js
@@ -838,14 +838,14 @@ class GrblController {
         // Grbl settings
         if (this.settings !== this.runner.settings) {
           this.settings = this.runner.settings;
-          this.emit('controller:settings', GRBL, this.settings);
+          this.emit('controller:settings', this.type, this.settings);
           this.emit('Grbl:settings', this.settings); // Backward compatibility
         }
 
         // Grbl state
         if (this.state !== this.runner.state) {
           this.state = this.runner.state;
-          this.emit('controller:state', GRBL, this.state);
+          this.emit('controller:state', this.type, this.state);
           this.emit('Grbl:state', this.state); // Backward compatibility
         }
 
@@ -1190,12 +1190,12 @@ class GrblController {
       }
       if (!_.isEmpty(this.settings)) {
         // controller settings
-        socket.emit('controller:settings', GRBL, this.settings);
+        socket.emit('controller:settings', this.type, this.settings);
         socket.emit('Grbl:settings', this.settings); // Backward compatibility
       }
       if (!_.isEmpty(this.state)) {
         // controller state
-        socket.emit('controller:state', GRBL, this.state);
+        socket.emit('controller:state', this.type, this.state);
         socket.emit('Grbl:state', this.state); // Backward compatibility
       }
       if (this.feeder) {

--- a/src/server/controllers/Grbl/constants.js
+++ b/src/server/controllers/Grbl/constants.js
@@ -1,6 +1,7 @@
 /* eslint max-len: 0 */
 // Grbl
 export const GRBL = 'Grbl';
+export const GRBLHAL = 'grblHAL';
 
 // Active State
 export const GRBL_ACTIVE_STATE_IDLE = 'Idle';

--- a/src/server/services/cncengine/CNCEngine.js
+++ b/src/server/services/cncengine/CNCEngine.js
@@ -251,6 +251,7 @@ class CNCEngine {
 
             const engine = this;
             controller = new Controller(engine, {
+              type: controllerType,
               port: port,
               baudrate: baudrate,
               rtscts: !!rtscts,

--- a/src/server/services/cncengine/CNCEngine.js
+++ b/src/server/services/cncengine/CNCEngine.js
@@ -15,7 +15,7 @@ import {
   SmoothieController,
   TinyGController
 } from '../../controllers';
-import { GRBL } from '../../controllers/Grbl/constants';
+import { GRBL, GRBLHAL } from '../../controllers/Grbl/constants';
 import { MARLIN } from '../../controllers/Marlin/constants';
 import { SMOOTHIE } from '../../controllers/Smoothie/constants';
 import { G2CORE, TINYG } from '../../controllers/TinyG/constants';
@@ -37,8 +37,9 @@ const caseInsensitiveEquals = (str1, str2) => {
 };
 
 const isValidController = (controller) => (
-  // Grbl
+  // Grbl / grblHAL
   caseInsensitiveEquals(GRBL, controller) ||
+    caseInsensitiveEquals(GRBLHAL, controller) ||
     // Marlin
     caseInsensitiveEquals(MARLIN, controller) ||
     // Smoothie
@@ -97,8 +98,9 @@ class CNCEngine {
         controller = '';
       }
 
-      // Grbl
-      if (!controller || caseInsensitiveEquals(GRBL, controller)) {
+      // Grbl / grblHAL
+      if (!controller || caseInsensitiveEquals(GRBL, controller) || caseInsensitiveEquals(GRBLHAL, controller)) {
+        this.controllerClass[GRBLHAL] = GrblController;
         this.controllerClass[GRBL] = GrblController;
       }
       // Marlin


### PR DESCRIPTION
## Summary
- introduce `grblHAL` constant alongside existing controller types
- allow selecting `grblHAL` through CLI and UI
- load `grblHAL` controller as a Grbl instance on the server
- update docs and examples for new controller option

## Testing
- `npm test` *(fails: The requested module 'react' does not provide an export named 'createContext')*

------
https://chatgpt.com/codex/tasks/task_e_687b17fd06c883218a236c89b2ca0e3b