### PR TITLE
Add dark mode option

### DIFF
--- a/examples/.cncrc
+++ b/examples/.cncrc
@@ -18,6 +18,7 @@
   "controller": "",
   "state": {
     "allowAnonymousUsageDataCollection": false,
+    "darkMode": false,
     "checkForUpdates": true,
     "controller": {
       "exception": {

--- a/src/app/containers/Settings/General/General.jsx
+++ b/src/app/containers/Settings/General/General.jsx
@@ -18,12 +18,17 @@ class General extends PureComponent {
 
     fields = {
       allowAnonymousUsageDataCollection: null,
+      darkMode: null,
     };
 
     handlers = {
       changeAllowAnonymousUsageDataCollection: (event) => {
         const { actions } = this.props;
         actions.toggleAllowAnonymousUsageDataCollection();
+      },
+      changeDarkMode: (event) => {
+        const { actions } = this.props;
+        actions.toggleDarkMode();
       },
       changeLanguage: (event) => {
         const { actions } = this.props;
@@ -76,6 +81,26 @@ class General extends PureComponent {
                       onChange={this.handlers.changeAllowAnonymousUsageDataCollection}
                     />
                     {i18n._('Enable anonymous usage data collection')}
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div style={{ marginBottom: 24 }}>
+            <h5>{i18n._('Appearance')}</h5>
+            <div className={styles.formFields}>
+              <div className={styles.formGroup}>
+                <div className="checkbox">
+                  <label>
+                    <input
+                      ref={(node) => {
+                        this.fields.darkMode = node;
+                      }}
+                      type="checkbox"
+                      checked={state.darkMode}
+                      onChange={this.handlers.changeDarkMode}
+                    />
+                    {i18n._('Dark mode')}
                   </label>
                 </div>
               </div>

--- a/src/app/containers/Settings/Settings.jsx
+++ b/src/app/containers/Settings/Settings.jsx
@@ -112,6 +112,7 @@ class Settings extends PureComponent {
             .then((res) => {
               const {
                 allowAnonymousUsageDataCollection,
+                darkMode,
               } = { ...res.body };
 
               const nextState = {
@@ -123,6 +124,7 @@ class Settings extends PureComponent {
                 },
                 // followed by data
                 allowAnonymousUsageDataCollection: !!allowAnonymousUsageDataCollection,
+                darkMode: !!darkMode,
                 lang: i18next.language // TODO: Store language settings into the state
               };
 
@@ -146,6 +148,7 @@ class Settings extends PureComponent {
         save: () => {
           const {
             allowAnonymousUsageDataCollection,
+            darkMode,
             lang = 'en',
           } = this.state.general;
 
@@ -162,6 +165,7 @@ class Settings extends PureComponent {
 
           const data = {
             allowAnonymousUsageDataCollection,
+            darkMode,
           };
 
           api.setState(data)
@@ -216,6 +220,15 @@ class Settings extends PureComponent {
             general: {
               ...this.state.general,
               allowAnonymousUsageDataCollection: !allowAnonymousUsageDataCollection,
+            }
+          });
+        },
+        toggleDarkMode: () => {
+          const { darkMode } = this.state.general;
+          this.setState({
+            general: {
+              ...this.state.general,
+              darkMode: !darkMode,
             }
           });
         },
@@ -1095,6 +1108,7 @@ class Settings extends PureComponent {
             saving: false
           },
           allowAnonymousUsageDataCollection: false,
+          darkMode: false,
           lang: i18next.language
         },
         // Workspace

--- a/src/app/containers/Settings/Settings.jsx
+++ b/src/app/containers/Settings/Settings.jsx
@@ -33,6 +33,14 @@ const mapSectionPathToId = (path = '') => {
   return _camelCase(path.split('/')[0] || '');
 };
 
+const applyDarkModeClass = (enabled) => {
+  const body = document.querySelector('body');
+  if (!body) {
+    return;
+  }
+  body.classList.toggle('dark-mode', enabled);
+};
+
 class Settings extends PureComponent {
     static propTypes = {
       ...withRouter.propTypes
@@ -130,7 +138,9 @@ class Settings extends PureComponent {
 
               this.initialState.general = nextState;
 
-              this.setState({ general: nextState });
+              this.setState({ general: nextState }, () => {
+                applyDarkModeClass(nextState.darkMode);
+              });
             })
             .catch((res) => {
               this.setState({
@@ -210,8 +220,11 @@ class Settings extends PureComponent {
         },
         restoreSettings: () => {
           // Restore settings from initialState
+          const { darkMode } = this.initialState.general;
           this.setState({
             general: this.initialState.general
+          }, () => {
+            applyDarkModeClass(darkMode);
           });
         },
         toggleAllowAnonymousUsageDataCollection: () => {
@@ -225,11 +238,14 @@ class Settings extends PureComponent {
         },
         toggleDarkMode: () => {
           const { darkMode } = this.state.general;
+          const next = !darkMode;
           this.setState({
             general: {
               ...this.state.general,
-              darkMode: !darkMode,
+              darkMode: next,
             }
+          }, () => {
+            applyDarkModeClass(next);
           });
         },
         changeLanguage: (lang) => {

--- a/src/app/i18n/en/resource.json
+++ b/src/app/i18n/en/resource.json
@@ -562,6 +562,8 @@
   "Use RTS/CTS flow control": "Use RTS/CTS flow control",
   "Data Collection": "Data Collection",
   "Enable anonymous usage data collection": "Enable anonymous usage data collection",
+  "Appearance": "Appearance",
+  "Dark mode": "Dark mode",
   "Display language:": "Display language:",
   "Tool Widget": "Tool Widget",
   "This widget manages workflows for tool changes.": "This widget manages workflows for tool changes.",

--- a/src/app/index.jsx
+++ b/src/app/index.jsx
@@ -100,7 +100,10 @@ series([
         if (authenticated) {
           try {
             const res = await api.getState();
-            const { allowAnonymousUsageDataCollection } = res.body || {};
+            const { allowAnonymousUsageDataCollection, darkMode } = res.body || {};
+            if (darkMode) {
+              document.body.classList.add('dark-mode');
+            }
             if (allowAnonymousUsageDataCollection && !GoogleAnalytics4.isInitialized) {
               GoogleAnalytics4.initialize([
                 {
@@ -174,6 +177,14 @@ series([
   { // Change backgrond color after loading complete
     const body = document.querySelector('body');
     body.style.backgroundColor = '#222'; // sidebar background color
+    try {
+      const res = await api.getState();
+      if (res.body?.darkMode) {
+        body.classList.add('dark-mode');
+      }
+    } catch (err) {
+      // ignore
+    }
   }
 
   if (settings.error.corruptedWorkspaceSettings) {

--- a/src/app/styles/app.styl
+++ b/src/app/styles/app.styl
@@ -26,3 +26,4 @@
 @import "ie";
 
 @import "table-form";
+@import "dark-mode";

--- a/src/app/styles/dark-mode.styl
+++ b/src/app/styles/dark-mode.styl
@@ -1,0 +1,16 @@
+body.dark-mode
+  color #ddd
+  background-color #222
+
+  a
+    color #9ecbff
+
+.navbar
+  background-color #111
+  border-color #111
+
+#sidebar
+  background-color #111
+
+.main
+  background-color #333

--- a/src/app/styles/dark-mode.styl
+++ b/src/app/styles/dark-mode.styl
@@ -14,3 +14,30 @@ body.dark-mode
 
 .main
   background-color #333
+body.dark-mode .widget
+  background-color #333
+  border-color #555
+  color #ddd
+
+body.dark-mode .widget-header,
+body.dark-mode .widget-footer
+  background-color #444
+  border-color #555
+  color #ddd
+
+body.dark-mode .panel,
+body.dark-mode .panel-body
+  background-color #333
+  color #ddd
+
+body.dark-mode .panel > .panel-heading
+  background-color #444
+  border-color #555
+  color #ddd
+
+body.dark-mode .gcode-viewer
+  background-color #222
+  border-color #555
+
+body.dark-mode .gcode-viewer-disabled
+  background-color #444

--- a/src/server/services/configstore/index.js
+++ b/src/server/services/configstore/index.js
@@ -9,6 +9,7 @@ const log = logger('service:configstore');
 
 const defaultState = { // default state
   allowAnonymousUsageDataCollection: false,
+  darkMode: false,
   checkForUpdates: true,
   controller: {
     exception: {


### PR DESCRIPTION
## Summary
- add `darkMode` setting to config store and example `.cncrc`
- support dark mode toggle in General settings
- load dark mode setting on startup
- include basic dark mode styles

## Testing
- `npm test` *(fails: tap not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b81185a18832188f448d18aedd96d