### PR TITLE
Add FluidNC widget and server API

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "is-electron": "~2.2.1",
     "jimp": "^0.10.3",
     "js-polyfills": "~0.1.42",
+    "js-yaml": "^4.1.0",
     "jsonwebtoken": "~9.0.0",
     "jsuri": "~1.3.1",
     "keycode": "~2.2.0",

--- a/src/app/api/index.js
+++ b/src/app/api/index.js
@@ -706,6 +706,18 @@ fluidnc.list = () => new Promise((resolve, reject) => {
     });
 });
 
+fluidnc.download = (name) => new Promise((resolve, reject) => {
+  authrequest
+    .get('/api/fluidnc/files/' + encodeURIComponent(name))
+    .end((err, res) => {
+      if (err) {
+        reject(res);
+      } else {
+        resolve(res);
+      }
+    });
+});
+
 fluidnc.upload = (options) => new Promise((resolve, reject) => {
   authrequest
     .post('/api/fluidnc/files')
@@ -722,6 +734,19 @@ fluidnc.upload = (options) => new Promise((resolve, reject) => {
 fluidnc.remove = (name) => new Promise((resolve, reject) => {
   authrequest
     .delete('/api/fluidnc/files/' + encodeURIComponent(name))
+    .end((err, res) => {
+      if (err) {
+        reject(res);
+      } else {
+        resolve(res);
+      }
+    });
+});
+
+fluidnc.setActive = (name) => new Promise((resolve, reject) => {
+  authrequest
+    .post('/api/fluidnc/active')
+    .send({ name })
     .end((err, res) => {
       if (err) {
         reject(res);

--- a/src/app/api/index.js
+++ b/src/app/api/index.js
@@ -692,6 +692,45 @@ machines.run = (id) => new Promise((resolve, reject) => {
     });
 });
 
+const fluidnc = {};
+
+fluidnc.list = () => new Promise((resolve, reject) => {
+  authrequest
+    .get('/api/fluidnc/files')
+    .end((err, res) => {
+      if (err) {
+        reject(res);
+      } else {
+        resolve(res);
+      }
+    });
+});
+
+fluidnc.upload = (options) => new Promise((resolve, reject) => {
+  authrequest
+    .post('/api/fluidnc/files')
+    .send(options)
+    .end((err, res) => {
+      if (err) {
+        reject(res);
+      } else {
+        resolve(res);
+      }
+    });
+});
+
+fluidnc.remove = (name) => new Promise((resolve, reject) => {
+  authrequest
+    .delete('/api/fluidnc/files/' + encodeURIComponent(name))
+    .end((err, res) => {
+      if (err) {
+        reject(res);
+      } else {
+        resolve(res);
+      }
+    });
+});
+
 export default {
   getLatestVersion,
 
@@ -725,4 +764,5 @@ export default {
   macros,
   mdi,
   users,
+  fluidnc,
 };

--- a/src/app/constants/index.js
+++ b/src/app/constants/index.js
@@ -66,6 +66,7 @@ export const METRIC_STEPS = [
 // Controller
 export const GRBL = 'Grbl';
 export const GRBLHAL = 'grblHAL';
+export const FLUIDNC = 'FluidNC';
 export const MARLIN = 'Marlin';
 export const SMOOTHIE = 'Smoothie';
 export const TINYG = 'TinyG';

--- a/src/app/containers/Workspace/PrimaryWidgets.jsx
+++ b/src/app/containers/Workspace/PrimaryWidgets.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Sortable from 'react-sortablejs';
 import uuid from 'uuid';
-import { GRBL, GRBLHAL, MARLIN, SMOOTHIE, TINYG } from 'app/constants';
+import { GRBL, GRBLHAL, FLUIDNC, MARLIN, SMOOTHIE, TINYG } from 'app/constants';
 import { Button } from 'app/components/Buttons';
 import Modal from 'app/components/Modal';
 import controller from 'app/lib/controller';
@@ -194,6 +194,9 @@ class PrimaryWidgets extends Component {
             return false;
           }
           if (name === 'grblhal' && !includes(controller.loadedControllers, GRBLHAL)) {
+            return false;
+          }
+          if (name === 'fluidnc' && !includes(controller.loadedControllers, FLUIDNC)) {
             return false;
           }
           if (name === 'marlin' && !includes(controller.loadedControllers, MARLIN)) {

--- a/src/app/containers/Workspace/SecondaryWidgets.jsx
+++ b/src/app/containers/Workspace/SecondaryWidgets.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Sortable from 'react-sortablejs';
 import uuid from 'uuid';
-import { GRBL, GRBLHAL, MARLIN, SMOOTHIE, TINYG } from 'app/constants';
+import { GRBL, GRBLHAL, FLUIDNC, MARLIN, SMOOTHIE, TINYG } from 'app/constants';
 import { Button } from 'app/components/Buttons';
 import Modal from 'app/components/Modal';
 import controller from 'app/lib/controller';
@@ -194,6 +194,9 @@ class SecondaryWidgets extends Component {
             return false;
           }
           if (name === 'grblhal' && !includes(controller.loadedControllers, GRBLHAL)) {
+            return false;
+          }
+          if (name === 'fluidnc' && !includes(controller.loadedControllers, FLUIDNC)) {
             return false;
           }
           if (name === 'marlin' && !includes(controller.loadedControllers, MARLIN)) {

--- a/src/app/containers/Workspace/Widget.jsx
+++ b/src/app/containers/Workspace/Widget.jsx
@@ -6,6 +6,7 @@ import ConsoleWidget from 'app/widgets/Console';
 import GCodeWidget from 'app/widgets/GCode';
 import GrblWidget from 'app/widgets/Grbl';
 import GrblHALWidget from 'app/widgets/GrblHAL';
+import FluidNCWidget from 'app/widgets/FluidNC';
 import LaserWidget from 'app/widgets/Laser';
 import MacroWidget from 'app/widgets/Macro';
 import MarlinWidget from 'app/widgets/Marlin';
@@ -27,6 +28,7 @@ const getWidgetByName = (name) => {
     'gcode': GCodeWidget,
     'grbl': GrblWidget,
     'grblhal': GrblHALWidget,
+    'fluidnc': FluidNCWidget,
     'laser': LaserWidget,
     'macro': MacroWidget,
     'marlin': MarlinWidget,

--- a/src/app/containers/Workspace/WidgetManager/WidgetManager.jsx
+++ b/src/app/containers/Workspace/WidgetManager/WidgetManager.jsx
@@ -5,7 +5,7 @@ import union from 'lodash/union';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import Modal from 'app/components/Modal';
-import { GRBL, GRBLHAL, MARLIN, SMOOTHIE, TINYG } from 'app/constants';
+import { GRBL, GRBLHAL, FLUIDNC, MARLIN, SMOOTHIE, TINYG } from 'app/constants';
 import controller from 'app/lib/controller';
 import i18n from 'app/lib/i18n';
 import store from 'app/store';
@@ -54,6 +54,13 @@ class WidgetManager extends PureComponent {
         id: 'grblhal',
         caption: i18n._('grblHAL Widget'),
         details: i18n._('This widget shows the grblHAL state and provides grblHAL specific features.'),
+        visible: true,
+        disabled: false
+      },
+      {
+        id: 'fluidnc',
+        caption: i18n._('FluidNC Widget'),
+        details: i18n._('This widget shows the FluidNC state and provides FluidNC specific features.'),
         visible: true,
         disabled: false
       },
@@ -174,6 +181,9 @@ class WidgetManager extends PureComponent {
           return false;
         }
         if (widgetItem.id === 'grblhal' && !includes(controller.loadedControllers, GRBLHAL)) {
+          return false;
+        }
+        if (widgetItem.id === 'fluidnc' && !includes(controller.loadedControllers, FLUIDNC)) {
           return false;
         }
         if (widgetItem.id === 'marlin' && !includes(controller.loadedControllers, MARLIN)) {

--- a/src/app/containers/Workspace/WidgetManager/index.jsx
+++ b/src/app/containers/Workspace/WidgetManager/index.jsx
@@ -3,7 +3,7 @@ import includes from 'lodash/includes';
 import union from 'lodash/union';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { GRBL, GRBLHAL, MARLIN, SMOOTHIE, TINYG } from 'app/constants';
+import { GRBL, GRBLHAL, FLUIDNC, MARLIN, SMOOTHIE, TINYG } from 'app/constants';
 import controller from 'app/lib/controller';
 import store from 'app/store';
 import defaultState from 'app/store/defaultState';
@@ -22,6 +22,12 @@ export const getActiveWidgets = () => {
         return false;
       }
       if (widget === 'grblhal' && !includes(controller.loadedControllers, GRBLHAL)) {
+        return false;
+      }
+      if (widget === 'fluidnc' && !includes(controller.loadedControllers, FLUIDNC)) {
+        return false;
+      }
+      if (widget === 'fluidnc' && !includes(controller.loadedControllers, FLUIDNC)) {
         return false;
       }
       if (widget === 'marlin' && !includes(controller.loadedControllers, MARLIN)) {

--- a/src/app/store/defaultState.js
+++ b/src/app/store/defaultState.js
@@ -16,7 +16,7 @@ const defaultState = {
       primary: {
         show: true,
         widgets: [
-          'connection', 'console', 'grbl', 'grblhal', 'marlin', 'smoothie', 'tinyg', 'webcam'
+          'connection', 'console', 'grbl', 'grblhal', 'fluidnc', 'marlin', 'smoothie', 'tinyg', 'webcam'
         ]
       },
       secondary: {
@@ -104,6 +104,20 @@ const defaultState = {
       }
     },
     grblhal: {
+      minimized: false,
+      panel: {
+        queueReports: {
+          expanded: true
+        },
+        statusReports: {
+          expanded: true
+        },
+        modalGroups: {
+          expanded: true
+        }
+      }
+    },
+    fluidnc: {
       minimized: false,
       panel: {
         queueReports: {

--- a/src/app/widgets/Connection/Connection.jsx
+++ b/src/app/widgets/Connection/Connection.jsx
@@ -13,6 +13,7 @@ import i18n from 'app/lib/i18n';
 import {
   GRBL,
   GRBLHAL,
+  FLUIDNC,
   MARLIN,
   SMOOTHIE,
   TINYG
@@ -117,6 +118,7 @@ class Connection extends PureComponent {
       const canSelectControllers = (controller.loadedControllers.length > 1);
       const hasGrblController = includes(controller.loadedControllers, GRBL);
       const hasGrblHALController = includes(controller.loadedControllers, GRBLHAL);
+      const hasFluidNCController = includes(controller.loadedControllers, FLUIDNC);
       const hasMarlinController = includes(controller.loadedControllers, MARLIN);
       const hasSmoothieController = includes(controller.loadedControllers, SMOOTHIE);
       const hasTinyGController = includes(controller.loadedControllers, TINYG);
@@ -175,6 +177,22 @@ class Connection extends PureComponent {
                       }}
                     >
                       {GRBLHAL}
+                    </button>
+                  )}
+                  {hasFluidNCController && (
+                    <button
+                      type="button"
+                      className={cx(
+                        'btn',
+                        'btn-default',
+                        { 'btn-select': controllerType === FLUIDNC }
+                      )}
+                      disabled={!canChangeController}
+                      onClick={() => {
+                        actions.changeController(FLUIDNC);
+                      }}
+                    >
+                      {FLUIDNC}
                     </button>
                   )}
                   {hasMarlinController && (

--- a/src/app/widgets/FluidNC/Controller.jsx
+++ b/src/app/widgets/FluidNC/Controller.jsx
@@ -1,0 +1,79 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Button } from 'app/components/Buttons';
+import Modal from 'app/components/Modal';
+import { Nav, NavItem } from 'app/components/Navs';
+import controller from 'app/lib/controller';
+import i18n from 'app/lib/i18n';
+import styles from './index.styl';
+
+const Controller = (props) => {
+  const { state, actions } = props;
+  const { activeTab = 'state' } = state.modal.params;
+  const height = Math.max(window.innerHeight / 2, 200);
+
+  return (
+    <Modal disableOverlay size="lg" onClose={actions.closeModal}>
+      <Modal.Header>
+        <Modal.Title>
+                    grblHAL
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Nav
+          navStyle="tabs"
+          activeKey={activeTab}
+          onSelect={(eventKey, event) => {
+            actions.updateModalParams({ activeTab: eventKey });
+          }}
+          style={{ marginBottom: 10 }}
+        >
+          <NavItem eventKey="state">{i18n._('Controller State')}</NavItem>
+          <NavItem eventKey="settings">{i18n._('Controller Settings')}</NavItem>
+        </Nav>
+        <div className={styles.navContent} style={{ height: height }}>
+          {activeTab === 'state' && (
+            <pre className={styles.pre}>
+              <code>{JSON.stringify(state.controller.state, null, 4)}</code>
+            </pre>
+          )}
+          {activeTab === 'settings' && (
+            <div>
+              <Button
+                btnSize="xs"
+                btnStyle="flat"
+                style={{
+                  position: 'absolute',
+                  right: 10,
+                  top: 10
+                }}
+                onClick={event => {
+                  controller.writeln('$#'); // Parameters
+                  controller.writeln('$$'); // Settings
+                }}
+              >
+                <i className="fa fa-refresh" />
+                {i18n._('Refresh')}
+              </Button>
+              <pre className={styles.pre}>
+                <code>{JSON.stringify(state.controller.settings, null, 4)}</code>
+              </pre>
+            </div>
+          )}
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button onClick={actions.closeModal}>
+          {i18n._('Close')}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+Controller.propTypes = {
+  state: PropTypes.object,
+  actions: PropTypes.object
+};
+
+export default Controller;

--- a/src/app/widgets/FluidNC/Controller.jsx
+++ b/src/app/widgets/FluidNC/Controller.jsx
@@ -16,7 +16,7 @@ const Controller = (props) => {
     <Modal disableOverlay size="lg" onClose={actions.closeModal}>
       <Modal.Header>
         <Modal.Title>
-                    grblHAL
+          FluidNC
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>

--- a/src/app/widgets/FluidNC/DigitalReadout.jsx
+++ b/src/app/widgets/FluidNC/DigitalReadout.jsx
@@ -1,0 +1,42 @@
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styles from './index.styl';
+
+const DigitalReadout = (props) => {
+  const { label, value, children } = props;
+
+  return (
+    <div className={classNames('row', 'no-gutters', styles.dro)}>
+      <div className="col col-xs-1">
+        <div className={styles.droLabel}>{label}</div>
+      </div>
+      <div className="col col-xs-2">
+        <div
+          className={classNames(
+            styles.well,
+            styles.droDisplay
+          )}
+        >
+          {value}
+        </div>
+      </div>
+      <div className="col col-xs-9">
+        <div className={styles.droBtnGroup}>
+          <div className="input-group input-group-sm">
+            <div className="input-group-btn">
+              {children}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+DigitalReadout.propTypes = {
+  label: PropTypes.string,
+  value: PropTypes.string
+};
+
+export default DigitalReadout;

--- a/src/app/widgets/FluidNC/FluidNC.jsx
+++ b/src/app/widgets/FluidNC/FluidNC.jsx
@@ -1,0 +1,332 @@
+import { ensureArray } from 'ensure-type';
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { ProgressBar } from 'react-bootstrap';
+import mapGCodeToText from 'app/lib/gcode-text';
+import i18n from 'app/lib/i18n';
+import Panel from 'app/components/Panel';
+import Toggler from 'app/components/Toggler';
+import Overrides from './Overrides';
+import styles from './index.styl';
+
+class FluidNC extends PureComponent {
+    static propTypes = {
+      state: PropTypes.object,
+      actions: PropTypes.object
+    };
+
+    // https://github.com/grbl/grbl/wiki/Interfacing-with-Grbl
+    // Grbl v0.9: BLOCK_BUFFER_SIZE (18), RX_BUFFER_SIZE (128)
+    // Grbl v1.1: BLOCK_BUFFER_SIZE (16), RX_BUFFER_SIZE (128)
+    plannerBufferMax = 0;
+
+    plannerBufferMin = 0;
+
+    receiveBufferMax = 128;
+
+    receiveBufferMin = 0;
+
+    render() {
+      const { state, actions } = this.props;
+      const none = '–';
+      const panel = state.panel;
+      const controllerState = state.controller.state || {};
+      const parserState = _.get(controllerState, 'parserstate', {});
+      const activeState = _.get(controllerState, 'status.activeState') || none;
+      const feedrate = _.get(controllerState, 'status.feedrate', _.get(parserState, 'feedrate', none));
+      const spindle = _.get(controllerState, 'status.spindle', _.get(parserState, 'spindle', none));
+      const tool = _.get(parserState, 'tool', none);
+      const ov = _.get(controllerState, 'status.ov', []);
+      const [ovF = 0, ovR = 0, ovS = 0] = ov;
+      const buf = _.get(controllerState, 'status.buf', {});
+      const modal = _.mapValues(parserState.modal || {}, mapGCodeToText);
+      const receiveBufferStyle = ((rx) => {
+        // danger: 0-7
+        // warning: 8-15
+        // info: >=16
+        rx = Number(rx) || 0;
+        if (rx >= 16) {
+          return 'info';
+        }
+        if (rx >= 8) {
+          return 'warning';
+        }
+        return 'danger';
+      })(buf.rx);
+
+      this.plannerBufferMax = Math.max(this.plannerBufferMax, buf.planner) || this.plannerBufferMax;
+      this.receiveBufferMax = Math.max(this.receiveBufferMax, buf.rx) || this.receiveBufferMax;
+
+      return (
+        <div>
+          <Overrides ovF={ovF} ovS={ovS} ovR={ovR} />
+          {!_.isEmpty(buf) && (
+            <Panel className={styles.panel}>
+              <Panel.Heading className={styles['panel-heading']}>
+                <Toggler
+                  className="clearfix"
+                  onToggle={actions.toggleQueueReports}
+                  title={panel.queueReports.expanded ? i18n._('Hide') : i18n._('Show')}
+                >
+                  <div className="pull-left">{i18n._('Queue Reports')}</div>
+                  <Toggler.Icon
+                    className="pull-right"
+                    expanded={panel.queueReports.expanded}
+                  />
+                </Toggler>
+              </Panel.Heading>
+              {panel.queueReports.expanded && (
+                <Panel.Body>
+                  <div className="row no-gutters">
+                    <div className="col col-xs-4">
+                      <div className={styles.textEllipsis} title={i18n._('Planner Buffer')}>
+                        {i18n._('Planner Buffer')}
+                      </div>
+                    </div>
+                    <div className="col col-xs-8">
+                      <ProgressBar
+                        style={{ marginBottom: 0 }}
+                        bsStyle="info"
+                        min={this.plannerBufferMin}
+                        max={this.plannerBufferMax}
+                        now={buf.planner}
+                        label={(
+                          <span className={styles.progressbarLabel}>
+                            {buf.planner}
+                          </span>
+                        )}
+                      />
+                    </div>
+                  </div>
+                  <div className="row no-gutters">
+                    <div className="col col-xs-4">
+                      <div className={styles.textEllipsis} title={i18n._('Receive Buffer')}>
+                        {i18n._('Receive Buffer')}
+                      </div>
+                    </div>
+                    <div className="col col-xs-8">
+                      <ProgressBar
+                        style={{ marginBottom: 0 }}
+                        bsStyle={receiveBufferStyle}
+                        min={this.receiveBufferMin}
+                        max={this.receiveBufferMax}
+                        now={buf.rx}
+                        label={(
+                          <span className={styles.progressbarLabel}>
+                            {buf.rx}
+                          </span>
+                        )}
+                      />
+                    </div>
+                  </div>
+                </Panel.Body>
+              )}
+            </Panel>
+          )}
+          <Panel className={styles.panel}>
+            <Panel.Heading className={styles['panel-heading']}>
+              <Toggler
+                className="clearfix"
+                onToggle={() => {
+                  actions.toggleStatusReports();
+                }}
+                title={panel.statusReports.expanded ? i18n._('Hide') : i18n._('Show')}
+              >
+                <div className="pull-left">{i18n._('Status Reports')}</div>
+                <Toggler.Icon
+                  className="pull-right"
+                  expanded={panel.statusReports.expanded}
+                />
+              </Toggler>
+            </Panel.Heading>
+            {panel.statusReports.expanded && (
+              <Panel.Body>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('State')}>
+                      {i18n._('State')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well}>
+                      {activeState}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Feed Rate')}>
+                      {i18n._('Feed Rate')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well}>
+                      {feedrate}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Spindle')}>
+                      {i18n._('Spindle')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well}>
+                      {spindle}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Tool Number')}>
+                      {i18n._('Tool Number')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well}>
+                      {tool}
+                    </div>
+                  </div>
+                </div>
+              </Panel.Body>
+            )}
+          </Panel>
+          <Panel className={styles.panel}>
+            <Panel.Heading className={styles['panel-heading']}>
+              <Toggler
+                className="clearfix"
+                onToggle={() => {
+                  actions.toggleModalGroups();
+                }}
+                title={panel.modalGroups.expanded ? i18n._('Hide') : i18n._('Show')}
+              >
+                <div className="pull-left">{i18n._('Modal Groups')}</div>
+                <Toggler.Icon
+                  className="pull-right"
+                  expanded={panel.modalGroups.expanded}
+                />
+              </Toggler>
+            </Panel.Heading>
+            {panel.modalGroups.expanded && (
+              <Panel.Body>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Motion')}>
+                      {i18n._('Motion')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well} title={modal.motion}>
+                      {modal.motion || none}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Coordinate')}>
+                      {i18n._('Coordinate')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well} title={modal.wcs}>
+                      {modal.wcs || none}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Plane')}>
+                      {i18n._('Plane')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well} title={modal.plane}>
+                      {modal.plane || none}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Distance')}>
+                      {i18n._('Distance')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well} title={modal.distance}>
+                      {modal.distance || none}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Feed Rate')}>
+                      {i18n._('Feed Rate')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well} title={modal.feedrate}>
+                      {modal.feedrate || none}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Units')}>
+                      {i18n._('Units')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well} title={modal.units}>
+                      {modal.units || none}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Program')}>
+                      {i18n._('Program')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well} title={modal.program}>
+                      {modal.program || none}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Spindle')}>
+                      {i18n._('Spindle')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well} title={modal.spindle}>
+                      {modal.spindle || none}
+                    </div>
+                  </div>
+                </div>
+                <div className="row no-gutters">
+                  <div className="col col-xs-4">
+                    <div className={styles.textEllipsis} title={i18n._('Coolant')}>
+                      {i18n._('Coolant')}
+                    </div>
+                  </div>
+                  <div className="col col-xs-8">
+                    <div className={styles.well}>
+                      {ensureArray(modal.coolant).map(coolant => (
+                        <div title={coolant} key={coolant}>{coolant || none}</div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </Panel.Body>
+            )}
+          </Panel>
+        </div>
+      );
+    }
+}
+
+export default FluidNC;

--- a/src/app/widgets/FluidNC/Overrides.jsx
+++ b/src/app/widgets/FluidNC/Overrides.jsx
@@ -1,0 +1,189 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import Space from 'app/components/Space';
+import RepeatButton from 'app/components/RepeatButton';
+import controller from 'app/lib/controller';
+import DigitalReadout from './DigitalReadout';
+import styles from './index.styl';
+
+const Overrides = (props) => {
+  const { ovF, ovS, ovR } = props;
+
+  if (!ovF && !ovS && !ovR) {
+    return null;
+  }
+
+  return (
+    <div className={styles.overrides}>
+      {!!ovF && (
+        <DigitalReadout label="F" value={ovF + '%'}>
+          <RepeatButton
+            className="btn btn-default"
+            style={{ padding: 5 }}
+            onClick={() => {
+              controller.command('feedOverride', -10);
+            }}
+          >
+            <i className="fa fa-arrow-down" style={{ fontSize: 14 }} />
+            <span style={{ marginLeft: 5 }}>
+                        -10%
+            </span>
+          </RepeatButton>
+          <RepeatButton
+            className="btn btn-default"
+            style={{ padding: 5 }}
+            onClick={() => {
+              controller.command('feedOverride', -1);
+            }}
+          >
+            <i className="fa fa-arrow-down" style={{ fontSize: 10 }} />
+            <span style={{ marginLeft: 5 }}>
+                        -1%
+            </span>
+          </RepeatButton>
+          <RepeatButton
+            className="btn btn-default"
+            style={{ padding: 5 }}
+            onClick={() => {
+              controller.command('feedOverride', 1);
+            }}
+          >
+            <i className="fa fa-arrow-up" style={{ fontSize: 10 }} />
+            <span style={{ marginLeft: 5 }}>
+                        1%
+            </span>
+          </RepeatButton>
+          <RepeatButton
+            className="btn btn-default"
+            style={{ padding: 5 }}
+            onClick={() => {
+              controller.command('feedOverride', 10);
+            }}
+          >
+            <i className="fa fa-arrow-up" style={{ fontSize: 14 }} />
+            <span style={{ marginLeft: 5 }}>
+                        10%
+            </span>
+          </RepeatButton>
+          <button
+            type="button"
+            className="btn btn-default"
+            style={{ padding: 5 }}
+            onClick={() => {
+              controller.command('feedOverride', 0);
+            }}
+          >
+            <i className="fa fa-undo fa-fw" />
+          </button>
+        </DigitalReadout>
+      )}
+      {!!ovS && (
+        <DigitalReadout label="S" value={ovS + '%'}>
+          <RepeatButton
+            className="btn btn-default"
+            style={{ padding: 5 }}
+            onClick={() => {
+              controller.command('spindleOverride', -10);
+            }}
+          >
+            <i className="fa fa-arrow-down" style={{ fontSize: 14 }} />
+            <span style={{ marginLeft: 5 }}>
+                        -10%
+            </span>
+          </RepeatButton>
+          <RepeatButton
+            className="btn btn-default"
+            style={{ padding: 5 }}
+            onClick={() => {
+              controller.command('spindleOverride', -1);
+            }}
+          >
+            <i className="fa fa-arrow-down" style={{ fontSize: 10 }} />
+            <span style={{ marginLeft: 5 }}>
+                        -1%
+            </span>
+          </RepeatButton>
+          <RepeatButton
+            className="btn btn-default"
+            style={{ padding: 5 }}
+            onClick={() => {
+              controller.command('spindleOverride', 1);
+            }}
+          >
+            <i className="fa fa-arrow-up" style={{ fontSize: 10 }} />
+            <span style={{ marginLeft: 5 }}>
+                        1%
+            </span>
+          </RepeatButton>
+          <RepeatButton
+            className="btn btn-default"
+            style={{ padding: 5 }}
+            onClick={() => {
+              controller.command('spindleOverride', 10);
+            }}
+          >
+            <i className="fa fa-arrow-up" style={{ fontSize: 14 }} />
+            <span style={{ marginLeft: 5 }}>
+                        10%
+            </span>
+          </RepeatButton>
+          <button
+            type="button"
+            className="btn btn-default"
+            style={{ padding: 5 }}
+            onClick={() => {
+              controller.command('spindleOverride', 0);
+            }}
+          >
+            <i className="fa fa-undo fa-fw" />
+          </button>
+        </DigitalReadout>
+      )}
+      {!!ovR && (
+        <DigitalReadout label="R" value={ovR + '%'}>
+          <button
+            type="button"
+            className="btn btn-default"
+            onClick={() => {
+              controller.command('rapidOverride', 100);
+            }}
+          >
+            <i className="fa fa-battery-full" />
+            <Space width="8" />
+                    100%
+          </button>
+          <button
+            type="button"
+            className="btn btn-default"
+            onClick={() => {
+              controller.command('rapidOverride', 50);
+            }}
+          >
+            <i className="fa fa-battery-half" />
+            <Space width="8" />
+                    50%
+          </button>
+          <button
+            type="button"
+            className="btn btn-default"
+            onClick={() => {
+              controller.command('rapidOverride', 25);
+            }}
+          >
+            <i className="fa fa-battery-quarter" />
+            <Space width="8" />
+                    25%
+          </button>
+        </DigitalReadout>
+      )}
+    </div>
+  );
+};
+
+Overrides.propTypes = {
+  ovF: PropTypes.number,
+  ovS: PropTypes.number,
+  ovR: PropTypes.number
+};
+
+export default Overrides;

--- a/src/app/widgets/FluidNC/Settings.jsx
+++ b/src/app/widgets/FluidNC/Settings.jsx
@@ -1,9 +1,12 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { Nav, NavItem } from 'app/components/Navs';
+import { Button } from 'app/components/Buttons';
 import Modal from 'app/components/Modal';
+import api from 'app/api';
 import controller from 'app/lib/controller';
 import i18n from 'app/lib/i18n';
+import yaml from 'js-yaml';
 
 class Settings extends PureComponent {
   static propTypes = {
@@ -13,11 +16,15 @@ class Settings extends PureComponent {
   state = {
     tab: 'files',
     files: [],
-    active: ''
+    active: '',
+    ip: '',
+    editFile: '',
+    editValues: {}
   };
 
   componentDidMount() {
     this.fetch();
+    this.queryIP();
   }
 
   fetch = () => {
@@ -64,9 +71,161 @@ class Settings extends PureComponent {
     controller.writeln('$LocalFS/List');
   };
 
+  queryIP = () => {
+    let ip = '';
+    const handle = (data) => {
+      String(data)
+        .split(/\r?\n/)
+        .map(line => line.trim())
+        .forEach((line) => {
+          const m = line.match(/IP=([^:]+):/);
+          if (m) {
+            ip = m[1];
+          }
+          if (line === 'ok') {
+            controller.removeListener('serialport:read', handle);
+            this.setState({ ip });
+          }
+        });
+    };
+    controller.addListener('serialport:read', handle);
+    controller.writeln('$I');
+  };
+
+  handleSetActive = async (name) => {
+    await api.fluidnc.setActive(name);
+    this.setState({ active: name });
+  };
+
+  handleDelete = async (name) => {
+    if (!window.confirm(i18n._('Delete {name}?', { name }))) { // eslint-disable-line no-alert
+      return;
+    }
+    await api.fluidnc.remove(name);
+    this.fetch();
+  };
+
+  handleDownload = async (name) => {
+    const res = await api.fluidnc.download(name);
+    const blob = new Blob([res.text], { type: 'text/plain' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = name;
+    a.click();
+    URL.revokeObjectURL(a.href);
+  };
+
+  handleUpload = () => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.onchange = async (e) => {
+      const file = e.target.files[0];
+      if (!file) {
+        return;
+      }
+      const text = await file.text();
+      await api.fluidnc.upload({ name: file.name, data: text });
+      this.fetch();
+    };
+    input.click();
+  };
+
+  handleEdit = async (name) => {
+    const res = await api.fluidnc.download(name);
+    let values = {};
+    try {
+      values = yaml.load(res.text) || {};
+    } catch (e) {
+      values = { raw: res.text };
+    }
+    this.setState({ editFile: name, editValues: values });
+  };
+
+  handleSave = async () => {
+    const { editFile, editValues } = this.state;
+    let data = '';
+    try {
+      data = yaml.dump(editValues);
+    } catch (e) {
+      data = typeof editValues.raw === 'string' ? editValues.raw : '';
+    }
+    await api.fluidnc.upload({ name: editFile, data });
+    this.setState({ editFile: '', editValues: {} });
+    this.fetch();
+  };
+
+  renderEditModal() {
+    const { editFile, editValues } = this.state;
+    if (!editFile) {
+      return null;
+    }
+
+    const renderField = (key, value) => {
+      if (typeof value === 'boolean') {
+        return (
+          <input
+            type="checkbox"
+            checked={value}
+            onChange={e => this.setState({ editValues: { ...editValues, [key]: e.target.checked } })}
+          />
+        );
+      }
+      if (typeof value === 'number') {
+        return (
+          <input
+            type="number"
+            value={value}
+            onChange={e => this.setState({ editValues: { ...editValues, [key]: Number(e.target.value) } })}
+          />
+        );
+      }
+      if (typeof value === 'string') {
+        return (
+          <input
+            type="text"
+            value={value}
+            onChange={e => this.setState({ editValues: { ...editValues, [key]: e.target.value } })}
+          />
+        );
+      }
+      return (
+        <textarea
+          className="form-control"
+          value={yaml.dump(value)}
+          rows={4}
+          onChange={e => this.setState({ editValues: { ...editValues, [key]: yaml.load(e.target.value) } })}
+        />
+      );
+    };
+
+    const entries = Object.keys(editValues).map(key => (
+      <tr key={key}>
+        <td>{key}</td>
+        <td>{renderField(key, editValues[key])}</td>
+      </tr>
+    ));
+
+    return (
+      <Modal size="lg" onClose={() => this.setState({ editFile: '', editValues: {} })}>
+        <Modal.Header>
+          <Modal.Title>{i18n._('Edit')} {editFile}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <table className="table table-bordered">
+            <tbody>{entries}</tbody>
+          </table>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={this.handleSave}>{i18n._('Save')}</Button>
+          <Button onClick={() => this.setState({ editFile: '', editValues: {} })}>{i18n._('Cancel')}</Button>
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+
   render() {
     const { actions } = this.props;
-    const { tab, files, active } = this.state;
+    const { tab, files, active, ip } = this.state;
     return (
       <Modal size="lg" onClose={actions.closeModal}>
         <Modal.Header>
@@ -79,13 +238,41 @@ class Settings extends PureComponent {
           </Nav>
           {tab === 'files' && (
             <div>
-              <ul>
-                {files.map(f => (
-                  <li key={f}>
-                    {f} {f === active && <strong>({i18n._('active')})</strong>}
-                  </li>
-                ))}
-              </ul>
+              <div style={{ marginBottom: 10 }}>
+                <strong>{i18n._('Device IP')}:</strong> {ip || i18n._('Unknown')}
+              </div>
+              <table className="table table-bordered">
+                <thead>
+                  <tr>
+                    <th>{i18n._('File')}</th>
+                    <th>{i18n._('Actions')}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {files.map(f => (
+                    <tr key={f}>
+                      <td>
+                        {f} {f === active && <strong>({i18n._('active')})</strong>}
+                      </td>
+                      <td>
+                        <Button btnSize="xs" onClick={() => this.handleDownload(f)}><i className="fa fa-download" /></Button>
+                        {' '}
+                        <Button btnSize="xs" onClick={() => this.handleEdit(f)}><i className="fa fa-pencil" /></Button>
+                        {' '}
+                        <Button btnSize="xs" onClick={() => this.handleDelete(f)} disabled={f === active}><i className="fa fa-trash" /></Button>
+                        {' '}
+                        <Button btnSize="xs" onClick={() => this.handleSetActive(f)} disabled={f === active}><i className="fa fa-star" /></Button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <div style={{ marginTop: 10 }}>
+                <Button btnSize="xs" onClick={this.fetch}><i className="fa fa-refresh" /> {i18n._('Refresh')}</Button>
+                {' '}
+                <Button btnSize="xs" onClick={this.handleUpload}><i className="fa fa-upload" /> {i18n._('Upload')}</Button>
+              </div>
+              {this.renderEditModal()}
             </div>
           )}
           {tab === 'calibrate' && (

--- a/src/app/widgets/FluidNC/Settings.jsx
+++ b/src/app/widgets/FluidNC/Settings.jsx
@@ -43,8 +43,11 @@ class Settings extends PureComponent {
       }
 
       if (readingFiles) {
-        if (!line.startsWith('[') && !line.startsWith('$')) {
-          files.push(line);
+        if (line.startsWith('[FILE:')) {
+          const match = line.match(/^\[FILE:(.*)\|SIZE:/);
+          if (match) {
+            files.push(match[1]);
+          }
         }
         return;
       }

--- a/src/app/widgets/FluidNC/Settings.jsx
+++ b/src/app/widgets/FluidNC/Settings.jsx
@@ -1,0 +1,63 @@
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { Nav, NavItem } from 'app/components/Navs';
+import Modal from 'app/components/Modal';
+import api from 'app/api';
+import i18n from 'app/lib/i18n';
+
+class Settings extends PureComponent {
+  static propTypes = {
+    actions: PropTypes.object
+  };
+
+  state = {
+    tab: 'files',
+    files: [],
+    active: ''
+  };
+
+  componentDidMount() {
+    this.fetch();
+  }
+
+  fetch = () => {
+    api.fluidnc.list().then(res => {
+      const { files = [], active } = res.body || {};
+      this.setState({ files, active });
+    });
+  };
+
+  render() {
+    const { actions } = this.props;
+    const { tab, files, active } = this.state;
+    return (
+      <Modal size="lg" onClose={actions.closeModal}>
+        <Modal.Header>
+          <Modal.Title>{i18n._('FluidNC Settings')}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Nav navStyle="tabs" activeKey={tab} onSelect={key => this.setState({ tab: key })} style={{ marginBottom: 10 }}>
+            <NavItem eventKey="files">{i18n._('File Manager')}</NavItem>
+            <NavItem eventKey="calibrate">{i18n._('Calibrate')}</NavItem>
+          </Nav>
+          {tab === 'files' && (
+            <div>
+              <ul>
+                {files.map(f => (
+                  <li key={f}>
+                    {f} {f === active && <strong>({i18n._('active')})</strong>}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {tab === 'calibrate' && (
+            <div>{i18n._('No calibration data')}</div>
+          )}
+        </Modal.Body>
+      </Modal>
+    );
+  }
+}
+
+export default Settings;

--- a/src/app/widgets/FluidNC/constants.js
+++ b/src/app/widgets/FluidNC/constants.js
@@ -1,0 +1,11 @@
+import constants from 'namespace-constants';
+
+export const {
+  MODAL_NONE,
+  MODAL_CONTROLLER,
+  MODAL_SETTINGS
+} = constants('widgets/FluidNC', [
+  'MODAL_NONE',
+  'MODAL_CONTROLLER',
+  'MODAL_SETTINGS'
+]);

--- a/src/app/widgets/FluidNC/index.jsx
+++ b/src/app/widgets/FluidNC/index.jsx
@@ -1,0 +1,429 @@
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import Space from 'app/components/Space';
+import Widget from 'app/components/Widget';
+import i18n from 'app/lib/i18n';
+import controller from 'app/lib/controller';
+import WidgetConfig from '../WidgetConfig';
+import FluidNC from './FluidNC';
+import Controller from './Controller';
+import Settings from './Settings';
+import {
+  FLUIDNC
+} from '../../constants';
+import {
+  MODAL_NONE,
+  MODAL_CONTROLLER,
+  MODAL_SETTINGS
+} from './constants';
+import styles from './index.styl';
+
+class FluidNCWidget extends PureComponent {
+    static propTypes = {
+      widgetId: PropTypes.string.isRequired,
+      onFork: PropTypes.func.isRequired,
+      onRemove: PropTypes.func.isRequired,
+      sortable: PropTypes.object
+    };
+
+    // Public methods
+    collapse = () => {
+      this.setState({ minimized: true });
+    };
+
+    expand = () => {
+      this.setState({ minimized: false });
+    };
+
+    config = new WidgetConfig(this.props.widgetId);
+
+    state = this.getInitialState();
+
+    actions = {
+      toggleFullscreen: () => {
+        const { minimized, isFullscreen } = this.state;
+        this.setState({
+          minimized: isFullscreen ? minimized : false,
+          isFullscreen: !isFullscreen
+        });
+      },
+      toggleMinimized: () => {
+        const { minimized } = this.state;
+        this.setState({ minimized: !minimized });
+      },
+      openModal: (name = MODAL_NONE, params = {}) => {
+        this.setState({
+          modal: {
+            name: name,
+            params: params
+          }
+        });
+      },
+      closeModal: () => {
+        this.setState({
+          modal: {
+            name: MODAL_NONE,
+            params: {}
+          }
+        });
+      },
+      updateModalParams: (params = {}) => {
+        this.setState({
+          modal: {
+            ...this.state.modal,
+            params: {
+              ...this.state.modal.params,
+              ...params
+            }
+          }
+        });
+      },
+      toggleQueueReports: () => {
+        const expanded = this.state.panel.queueReports.expanded;
+
+        this.setState({
+          panel: {
+            ...this.state.panel,
+            queueReports: {
+              ...this.state.panel.queueReports,
+              expanded: !expanded
+            }
+          }
+        });
+      },
+      toggleStatusReports: () => {
+        const expanded = this.state.panel.statusReports.expanded;
+
+        this.setState({
+          panel: {
+            ...this.state.panel,
+            statusReports: {
+              ...this.state.panel.statusReports,
+              expanded: !expanded
+            }
+          }
+        });
+      },
+      toggleModalGroups: () => {
+        const expanded = this.state.panel.modalGroups.expanded;
+
+        this.setState({
+          panel: {
+            ...this.state.panel,
+            modalGroups: {
+              ...this.state.panel.modalGroups,
+              expanded: !expanded
+            }
+          }
+        });
+      }
+    };
+
+    controllerEvents = {
+      'serialport:open': (options) => {
+        const { port, controllerType } = options;
+        this.setState({
+          isReady: controllerType === FLUIDNC,
+          port: port
+        });
+      },
+      'serialport:close': (options) => {
+        const initialState = this.getInitialState();
+        this.setState({ ...initialState });
+      },
+      'controller:settings': (type, controllerSettings) => {
+        if (type === FLUIDNC) {
+          this.setState(state => ({
+            controller: {
+              ...state.controller,
+              type: type,
+              settings: controllerSettings
+            }
+          }));
+        }
+      },
+      'controller:state': (type, controllerState) => {
+        if (type === FLUIDNC) {
+          this.setState(state => ({
+            controller: {
+              ...state.controller,
+              type: type,
+              state: controllerState
+            }
+          }));
+        }
+      }
+    };
+
+    componentDidMount() {
+      this.addControllerEvents();
+    }
+
+    componentWillUnmount() {
+      this.removeControllerEvents();
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+      const {
+        minimized,
+        panel
+      } = this.state;
+
+      this.config.set('minimized', minimized);
+      this.config.set('panel.queueReports.expanded', panel.queueReports.expanded);
+      this.config.set('panel.statusReports.expanded', panel.statusReports.expanded);
+      this.config.set('panel.modalGroups.expanded', panel.modalGroups.expanded);
+    }
+
+    getInitialState() {
+      return {
+        minimized: this.config.get('minimized', false),
+        isFullscreen: false,
+        isReady: (controller.loadedControllers.length === 1) || (controller.type === FLUIDNC),
+        canClick: true, // Defaults to true
+        port: controller.port,
+        controller: {
+          type: controller.type,
+          settings: controller.settings,
+          state: controller.state
+        },
+        modal: {
+          name: MODAL_NONE,
+          params: {}
+        },
+        panel: {
+          queueReports: {
+            expanded: this.config.get('panel.queueReports.expanded')
+          },
+          statusReports: {
+            expanded: this.config.get('panel.statusReports.expanded')
+          },
+          modalGroups: {
+            expanded: this.config.get('panel.modalGroups.expanded')
+          }
+        }
+      };
+    }
+
+    addControllerEvents() {
+      Object.keys(this.controllerEvents).forEach(eventName => {
+        const callback = this.controllerEvents[eventName];
+        controller.addListener(eventName, callback);
+      });
+    }
+
+    removeControllerEvents() {
+      Object.keys(this.controllerEvents).forEach(eventName => {
+        const callback = this.controllerEvents[eventName];
+        controller.removeListener(eventName, callback);
+      });
+    }
+
+    canClick() {
+      const { port } = this.state;
+      const { type } = this.state.controller;
+
+      if (!port) {
+        return false;
+      }
+      if (type !== FLUIDNC) {
+        return false;
+      }
+
+      return true;
+    }
+
+    render() {
+      const { widgetId } = this.props;
+      const { minimized, isFullscreen, isReady } = this.state;
+      const isForkedWidget = widgetId.match(/\w+:[\w\-]+/);
+      const state = {
+        ...this.state,
+        canClick: this.canClick()
+      };
+      const actions = {
+        ...this.actions
+      };
+
+      return (
+        <Widget fullscreen={isFullscreen}>
+          <Widget.Header>
+            <Widget.Title>
+              <Widget.Sortable className={this.props.sortable.handleClassName}>
+                <i className="fa fa-bars" />
+                <Space width="8" />
+              </Widget.Sortable>
+              {isForkedWidget &&
+                <i className="fa fa-code-fork" style={{ marginRight: 5 }} />
+              }
+                        FluidNC
+            </Widget.Title>
+            <Widget.Controls className={this.props.sortable.filterClassName}>
+              {isReady && (
+                <Widget.Button
+                  onClick={(event) => {
+                    actions.openModal(MODAL_CONTROLLER);
+                  }}
+                >
+                  <i className="fa fa-info" />
+                </Widget.Button>
+              )}
+              {isReady && (
+                <Widget.Button
+                  onClick={() => actions.openModal(MODAL_SETTINGS)}
+                >
+                  <i className="fa fa-sliders" />
+                </Widget.Button>
+              )}
+              {isReady && (
+                <Widget.DropdownButton
+                  toggle={<i className="fa fa-th-large" />}
+                >
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.write('?')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('Status Report (?)')}
+                  </Widget.DropdownMenuItem>
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.writeln('$C')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('Check G-code Mode ($C)')}
+                  </Widget.DropdownMenuItem>
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.command('homing')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('Homing ($H)')}
+                  </Widget.DropdownMenuItem>
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.command('unlock')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('Kill Alarm Lock ($X)')}
+                  </Widget.DropdownMenuItem>
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.command('sleep')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('Sleep ($SLP)')}
+                  </Widget.DropdownMenuItem>
+                  <Widget.DropdownMenuItem divider />
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.writeln('$')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('Help ($)')}
+                  </Widget.DropdownMenuItem>
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.writeln('$$')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('Settings ($$)')}
+                  </Widget.DropdownMenuItem>
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.writeln('$#')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('View G-code Parameters ($#)')}
+                  </Widget.DropdownMenuItem>
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.writeln('$G')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('View G-code Parser State ($G)')}
+                  </Widget.DropdownMenuItem>
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.writeln('$I')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('View Build Info ($I)')}
+                  </Widget.DropdownMenuItem>
+                  <Widget.DropdownMenuItem
+                    onSelect={() => controller.writeln('$N')}
+                    disabled={!state.canClick}
+                  >
+                    {i18n._('View Startup Blocks ($N)')}
+                  </Widget.DropdownMenuItem>
+                </Widget.DropdownButton>
+              )}
+              {isReady && (
+                <Widget.Button
+                  disabled={isFullscreen}
+                  title={minimized ? i18n._('Expand') : i18n._('Collapse')}
+                  onClick={actions.toggleMinimized}
+                >
+                  <i
+                    className={classNames(
+                      'fa',
+                      { 'fa-chevron-up': !minimized },
+                      { 'fa-chevron-down': minimized }
+                    )}
+                  />
+                </Widget.Button>
+              )}
+              <Widget.DropdownButton
+                title={i18n._('More')}
+                toggle={<i className="fa fa-ellipsis-v" />}
+                onSelect={(eventKey) => {
+                  if (eventKey === 'fullscreen') {
+                    actions.toggleFullscreen();
+                  } else if (eventKey === 'fork') {
+                    this.props.onFork();
+                  } else if (eventKey === 'remove') {
+                    this.props.onRemove();
+                  }
+                }}
+              >
+                <Widget.DropdownMenuItem eventKey="fullscreen" disabled={!isReady}>
+                  <i
+                    className={classNames(
+                      'fa',
+                      'fa-fw',
+                      { 'fa-expand': !isFullscreen },
+                      { 'fa-compress': isFullscreen }
+                    )}
+                  />
+                  <Space width="4" />
+                  {!isFullscreen ? i18n._('Enter Full Screen') : i18n._('Exit Full Screen')}
+                </Widget.DropdownMenuItem>
+                <Widget.DropdownMenuItem eventKey="fork">
+                  <i className="fa fa-fw fa-code-fork" />
+                  <Space width="4" />
+                  {i18n._('Fork Widget')}
+                </Widget.DropdownMenuItem>
+                <Widget.DropdownMenuItem eventKey="remove">
+                  <i className="fa fa-fw fa-times" />
+                  <Space width="4" />
+                  {i18n._('Remove Widget')}
+                </Widget.DropdownMenuItem>
+              </Widget.DropdownButton>
+            </Widget.Controls>
+          </Widget.Header>
+          {isReady && (
+            <Widget.Content
+              className={classNames(
+                styles['widget-content'],
+                { [styles.hidden]: minimized }
+              )}
+            >
+              {state.modal.name === MODAL_CONTROLLER &&
+                <Controller state={state} actions={actions} />
+              }
+              {state.modal.name === MODAL_SETTINGS &&
+                <Settings state={state} actions={actions} />
+              }
+              <FluidNC
+                state={state}
+                actions={actions}
+              />
+            </Widget.Content>
+          )}
+        </Widget>
+      );
+    }
+}
+
+export default FluidNCWidget;

--- a/src/app/widgets/FluidNC/index.styl
+++ b/src/app/widgets/FluidNC/index.styl
@@ -1,0 +1,124 @@
+.widget-content {
+    position: relative;
+    padding: 10px;
+
+    &.hidden {
+        display: none;
+    }
+}
+
+.overrides {
+    margin-bottom: 10px;
+
+    .dro {
+        margin-bottom: 10px;
+    }
+
+    .dro-label,
+    .dro-display,
+    .dro-btn-group {
+        height: 30px;
+    }
+    .dro-label {
+        font-size: 24px;
+        line-height: initial;
+        text-align: left;
+    }
+    .dro-display {
+        padding: 4px 6px;
+        text-align: right;
+        font-size: 14px;
+        text-overflow: initial;
+        margin-right: 5px;
+    }
+    .dro-btn-group {
+        margin-left: 5px;
+    }
+    .dro-btn {
+        padding: 5px 5px;
+    }
+}
+
+.panel {
+    margin-bottom: 10px;
+
+    &:last-child {
+        margin-bottom: 0;
+    }
+
+    :global {
+        .row {
+            margin-bottom: 5px;
+        }
+        .row:last-child {
+            margin-bottom: 0;
+        }
+    }
+}
+.panel-heading:hover {
+    background-color: rgba(0, 0, 0, .05);
+}
+
+.progressbar-label {
+    color: #222;
+    padding: 0 10px;
+}
+
+.text-ellipsis {
+    white-space: nowrap;
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.well {
+    min-height: 22px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    background-color: #f5f5f5;
+    border: 1px solid #e3e3e3;
+    border-radius: 3px;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, .05);
+    margin-bottom: 0;
+    padding: 0 5px;
+}
+
+.nav-content {
+    position: relative;
+    overflow-y: auto;
+    background: #000;
+    color: #fff;
+    border: 1px solid #ddd;
+
+    .pre {
+        display: block;
+        font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif;
+        color: inherit;
+        background: inherit;
+        border: 0;
+        border-radius: 0;
+        margin: 0;
+        padding: 10px;
+    }
+}
+
+.settingsTable {
+    width: 100%;
+    th {
+        text-align: left;
+        padding: 4px;
+    }
+    td {
+        padding: 4px;
+    }
+}
+
+.settingsModalBody {
+    max-height: 60vh;
+    overflow-y: auto;
+}
+
+.settingsSection {
+    margin-bottom: 10px;
+}

--- a/src/app/widgets/FluidNC/settingsInfo.js
+++ b/src/app/widgets/FluidNC/settingsInfo.js
@@ -1,0 +1,43 @@
+export const SETTINGS_INFO = [
+  { setting: '$0', message: 'Step pulse time', units: 'microseconds' },
+  { setting: '$1', message: 'Step idle delay', units: 'milliseconds' },
+  { setting: '$2', message: 'Step pulse invert', units: 'mask' },
+  { setting: '$3', message: 'Step direction invert', units: 'mask' },
+  { setting: '$4', message: 'Invert step enable pin', units: 'boolean' },
+  { setting: '$5', message: 'Invert limit pins', units: 'boolean' },
+  { setting: '$6', message: 'Invert probe pin', units: 'boolean' },
+  { setting: '$10', message: 'Status report options', units: 'mask' },
+  { setting: '$11', message: 'Junction deviation', units: 'millimeters' },
+  { setting: '$12', message: 'Arc tolerance', units: 'millimeters' },
+  { setting: '$13', message: 'Report in inches', units: 'boolean' },
+  { setting: '$20', message: 'Soft limits enable', units: 'boolean' },
+  { setting: '$21', message: 'Hard limits enable', units: 'boolean' },
+  { setting: '$22', message: 'Homing cycle enable', units: 'boolean' },
+  { setting: '$23', message: 'Homing direction invert', units: 'mask' },
+  { setting: '$24', message: 'Homing locate feed rate', units: 'mm/min' },
+  { setting: '$25', message: 'Homing search seek rate', units: 'mm/min' },
+  { setting: '$26', message: 'Homing switch debounce delay', units: 'milliseconds' },
+  { setting: '$27', message: 'Homing switch pull-off distance', units: 'millimeters' },
+  { setting: '$30', message: 'Maximum spindle speed', units: 'RPM' },
+  { setting: '$31', message: 'Minimum spindle speed', units: 'RPM' },
+  { setting: '$32', message: 'Laser-mode enable', units: 'boolean' },
+  { setting: '$100', message: 'X-axis travel resolution', units: 'step/mm' },
+  { setting: '$101', message: 'Y-axis travel resolution', units: 'step/mm' },
+  { setting: '$102', message: 'Z-axis travel resolution', units: 'step/mm' },
+  { setting: '$110', message: 'X-axis maximum rate', units: 'mm/min' },
+  { setting: '$111', message: 'Y-axis maximum rate', units: 'mm/min' },
+  { setting: '$112', message: 'Z-axis maximum rate', units: 'mm/min' },
+  { setting: '$120', message: 'X-axis acceleration', units: 'mm/sec^2' },
+  { setting: '$121', message: 'Y-axis acceleration', units: 'mm/sec^2' },
+  { setting: '$122', message: 'Z-axis acceleration', units: 'mm/sec^2' },
+  { setting: '$130', message: 'X-axis maximum travel', units: 'millimeters' },
+  { setting: '$131', message: 'Y-axis maximum travel', units: 'millimeters' },
+  { setting: '$132', message: 'Z-axis maximum travel', units: 'millimeters' }
+];
+
+export const SETTINGS_CATEGORIES = {
+  'General': ['$0', '$1', '$2', '$3', '$4', '$5', '$6', '$10', '$11', '$12', '$13'],
+  'Homing & Limits': ['$20', '$21', '$22', '$23', '$24', '$25', '$26', '$27'],
+  'Spindle/Laser': ['$30', '$31', '$32'],
+  'Axes': ['$100', '$101', '$102', '$110', '$111', '$112', '$120', '$121', '$122', '$130', '$131', '$132']
+};

--- a/src/server/api/api.fluidnc.js
+++ b/src/server/api/api.fluidnc.js
@@ -41,6 +41,35 @@ export const upload = (req, res) => {
   }
 };
 
+export const download = (req, res) => {
+  const name = req.params.name;
+  try {
+    ensureDir();
+    const data = fs.readFileSync(path.join(dir, name), 'utf8');
+    res.type('text/plain').send(data);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      res.status(ERR_NOT_FOUND).send({ msg: 'File not found' });
+    } else {
+      res.status(ERR_INTERNAL_SERVER_ERROR).send({ msg: 'Failed to read file' });
+    }
+  }
+};
+
+export const setActive = (req, res) => {
+  const { name } = { ...req.body };
+  if (!name) {
+    res.status(ERR_BAD_REQUEST).send({ msg: 'Missing name' });
+    return;
+  }
+  try {
+    config.set(ACTIVE_KEY, name);
+    res.send({ err: null });
+  } catch (err) {
+    res.status(ERR_INTERNAL_SERVER_ERROR).send({ msg: 'Failed to set active config' });
+  }
+};
+
 export const remove = (req, res) => {
   const name = req.params.name;
   const active = config.get(ACTIVE_KEY, '');

--- a/src/server/api/api.fluidnc.js
+++ b/src/server/api/api.fluidnc.js
@@ -5,10 +5,19 @@ import config from '../services/configstore';
 import { ERR_BAD_REQUEST, ERR_NOT_FOUND, ERR_INTERNAL_SERVER_ERROR } from '../constants';
 
 const dir = path.resolve(settings.fluidnc.dir);
+
+const ensureDir = () => {
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch (err) {
+    // ignore
+  }
+};
 const ACTIVE_KEY = 'fluidnc.activeConfig';
 
 export const list = (req, res) => {
   try {
+    ensureDir();
     const files = fs.readdirSync(dir);
     const active = config.get(ACTIVE_KEY, '');
     res.send({ files, active });
@@ -24,6 +33,7 @@ export const upload = (req, res) => {
     return;
   }
   try {
+    ensureDir();
     fs.writeFileSync(path.join(dir, name), data, 'utf8');
     res.send({ err: null });
   } catch (err) {
@@ -39,6 +49,7 @@ export const remove = (req, res) => {
     return;
   }
   try {
+    ensureDir();
     fs.unlinkSync(path.join(dir, name));
     res.send({ err: null });
   } catch (err) {

--- a/src/server/api/api.fluidnc.js
+++ b/src/server/api/api.fluidnc.js
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import path from 'path';
+import settings from '../config/settings';
+import config from '../services/configstore';
+import { ERR_BAD_REQUEST, ERR_NOT_FOUND, ERR_INTERNAL_SERVER_ERROR } from '../constants';
+
+const dir = path.resolve(settings.fluidnc.dir);
+const ACTIVE_KEY = 'fluidnc.activeConfig';
+
+export const list = (req, res) => {
+  try {
+    const files = fs.readdirSync(dir);
+    const active = config.get(ACTIVE_KEY, '');
+    res.send({ files, active });
+  } catch (err) {
+    res.status(ERR_INTERNAL_SERVER_ERROR).send({ msg: 'Failed to list files' });
+  }
+};
+
+export const upload = (req, res) => {
+  const { name, data } = { ...req.body };
+  if (!name || data == null) {
+    res.status(ERR_BAD_REQUEST).send({ msg: 'Missing data' });
+    return;
+  }
+  try {
+    fs.writeFileSync(path.join(dir, name), data, 'utf8');
+    res.send({ err: null });
+  } catch (err) {
+    res.status(ERR_INTERNAL_SERVER_ERROR).send({ msg: 'Failed to save file' });
+  }
+};
+
+export const remove = (req, res) => {
+  const name = req.params.name;
+  const active = config.get(ACTIVE_KEY, '');
+  if (name === active) {
+    res.status(ERR_BAD_REQUEST).send({ msg: 'Cannot delete active config' });
+    return;
+  }
+  try {
+    fs.unlinkSync(path.join(dir, name));
+    res.send({ err: null });
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      res.status(ERR_NOT_FOUND).send({ msg: 'File not found' });
+    } else {
+      res.status(ERR_INTERNAL_SERVER_ERROR).send({ msg: 'Failed to delete file' });
+    }
+  }
+};

--- a/src/server/api/index.js
+++ b/src/server/api/index.js
@@ -10,6 +10,7 @@ import * as macros from './api.macros';
 import * as mdi from './api.mdi';
 import * as users from './api.users';
 import * as tool from './api.tool';
+import * as fluidnc from './api.fluidnc';
 
 export {
   version,
@@ -24,4 +25,5 @@ export {
   mdi,
   users,
   tool,
+  fluidnc,
 };

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -266,7 +266,9 @@ const appMain = () => {
 
     // FluidNC files
     app.get(urljoin(settings.route, 'api/fluidnc/files'), api.fluidnc.list);
+    app.get(urljoin(settings.route, 'api/fluidnc/files/:name'), api.fluidnc.download);
     app.post(urljoin(settings.route, 'api/fluidnc/files'), api.fluidnc.upload);
+    app.post(urljoin(settings.route, 'api/fluidnc/active'), api.fluidnc.setActive);
     app.delete(urljoin(settings.route, 'api/fluidnc/files/:name'), api.fluidnc.remove);
 
     // G-code

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -264,6 +264,11 @@ const appMain = () => {
     app.get(urljoin(settings.route, 'api/tool'), api.tool.get);
     app.post(urljoin(settings.route, 'api/tool'), api.tool.set);
 
+    // FluidNC files
+    app.get(urljoin(settings.route, 'api/fluidnc/files'), api.fluidnc.list);
+    app.post(urljoin(settings.route, 'api/fluidnc/files'), api.fluidnc.upload);
+    app.delete(urljoin(settings.route, 'api/fluidnc/files/:name'), api.fluidnc.remove);
+
     // G-code
     app.get(urljoin(settings.route, 'api/gcode'), api.gcode.fetch);
     app.post(urljoin(settings.route, 'api/gcode'), api.gcode.upload);

--- a/src/server/config/settings.base.js
+++ b/src/server/config/settings.base.js
@@ -95,6 +95,9 @@ export default {
   siofu: { // SocketIOFileUploader
     dir: './tmp/siofu'
   },
+  fluidnc: {
+    dir: path.resolve(getUserHome(), 'fluidnc')
+  },
   i18next: {
     lowerCaseLng: true,
 

--- a/src/server/controllers/Grbl/constants.js
+++ b/src/server/controllers/Grbl/constants.js
@@ -2,6 +2,7 @@
 // Grbl
 export const GRBL = 'Grbl';
 export const GRBLHAL = 'grblHAL';
+export const FLUIDNC = 'FluidNC';
 
 // Active State
 export const GRBL_ACTIVE_STATE_IDLE = 'Idle';

--- a/src/server/services/cncengine/CNCEngine.js
+++ b/src/server/services/cncengine/CNCEngine.js
@@ -15,7 +15,7 @@ import {
   SmoothieController,
   TinyGController
 } from '../../controllers';
-import { GRBL, GRBLHAL } from '../../controllers/Grbl/constants';
+import { GRBL, GRBLHAL, FLUIDNC } from '../../controllers/Grbl/constants';
 import { MARLIN } from '../../controllers/Marlin/constants';
 import { SMOOTHIE } from '../../controllers/Smoothie/constants';
 import { G2CORE, TINYG } from '../../controllers/TinyG/constants';
@@ -37,9 +37,10 @@ const caseInsensitiveEquals = (str1, str2) => {
 };
 
 const isValidController = (controller) => (
-  // Grbl / grblHAL
+  // Grbl / grblHAL / FluidNC
   caseInsensitiveEquals(GRBL, controller) ||
     caseInsensitiveEquals(GRBLHAL, controller) ||
+    caseInsensitiveEquals(FLUIDNC, controller) ||
     // Marlin
     caseInsensitiveEquals(MARLIN, controller) ||
     // Smoothie
@@ -98,10 +99,11 @@ class CNCEngine {
         controller = '';
       }
 
-      // Grbl / grblHAL
-      if (!controller || caseInsensitiveEquals(GRBL, controller) || caseInsensitiveEquals(GRBLHAL, controller)) {
+      // Grbl / grblHAL / FluidNC
+      if (!controller || caseInsensitiveEquals(GRBL, controller) || caseInsensitiveEquals(GRBLHAL, controller) || caseInsensitiveEquals(FLUIDNC, controller)) {
         this.controllerClass[GRBLHAL] = GrblController;
         this.controllerClass[GRBL] = GrblController;
+        this.controllerClass[FLUIDNC] = GrblController;
       }
       // Marlin
       if (!controller || caseInsensitiveEquals(MARLIN, controller)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8078,6 +8078,7 @@ __metadata:
     is-electron: ~2.2.1
     jimp: ^0.10.3
     js-polyfills: ~0.1.42
+    js-yaml: ^4.1.0
     json-loader: ~0.5.7
     jsonlint: ^1.6.3
     jsonwebtoken: ~9.0.0


### PR DESCRIPTION
## Summary
- support FluidNC controller type
- create FluidNC widget based on GrblHAL
- expose REST endpoints for FluidNC file management
- wire up widget manager and default state for FluidNC

## Testing
- `npm run lint` *(fails: concurrently not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c9a084e908321b84e87ea16525c70